### PR TITLE
Update clang-format and formatting Codes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,95 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ _external/
 core.*
 \#*\#
 !.gitignore
+!.clang-format
 *.so
 *.a
 vgcore.*

--- a/async_simple/Common.h
+++ b/async_simple/Common.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/Executor.h
+++ b/async_simple/Executor.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -162,8 +162,7 @@ public:
     }
 
     template <typename PromiseType>
-    void await_suspend(
-        STD_CORO::coroutine_handle<PromiseType> continuation) {
+    void await_suspend(STD_CORO::coroutine_handle<PromiseType> continuation) {
         std::function<void()> func = [c = continuation]() mutable {
             c.resume();
         };
@@ -199,8 +198,7 @@ public:
     bool await_ready() const noexcept { return false; }
 
     template <typename PromiseType>
-    void await_suspend(
-        STD_CORO::coroutine_handle<PromiseType> continuation) {
+    void await_suspend(STD_CORO::coroutine_handle<PromiseType> continuation) {
         std::function<void()> func = [c = continuation]() mutable {
             c.resume();
         };

--- a/async_simple/Future.h
+++ b/async_simple/Future.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/FutureState.h
+++ b/async_simple/FutureState.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/Helper.h
+++ b/async_simple/Helper.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/IOExecutor.h
+++ b/async_simple/IOExecutor.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/LocalState.h
+++ b/async_simple/LocalState.h
@@ -1,13 +1,13 @@
 
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/Promise.h
+++ b/async_simple/Promise.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/Traits.h
+++ b/async_simple/Traits.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/Unit.h
+++ b/async_simple/Unit.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -155,8 +155,7 @@ struct CollectAllAwaiter {
     CollectAllAwaiter& operator=(const CollectAllAwaiter&) = delete;
 
     inline bool await_ready() const noexcept { return _input.empty(); }
-    inline void await_suspend(
-        STD_CORO::coroutine_handle<> continuation) {
+    inline void await_suspend(STD_CORO::coroutine_handle<> continuation) {
         auto promise_type =
             static_cast<STD_CORO::coroutine_handle<LazyPromiseBase>*>(
                 &continuation)

--- a/async_simple/coro/Event.h
+++ b/async_simple/coro/Event.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -65,8 +65,7 @@ public:
     struct FinalAwaiter {
         bool await_ready() const noexcept { return false; }
         template <typename PromiseType>
-        auto await_suspend(
-            STD_CORO::coroutine_handle<PromiseType> h) noexcept {
+        auto await_suspend(STD_CORO::coroutine_handle<PromiseType> h) noexcept {
             return h.promise()._continuation;
         }
         void await_resume() noexcept {}
@@ -344,8 +343,7 @@ public:
         AwaiterBase(Handle coro) : Base(coro) {}
 
         __attribute__((__always_inline__)) STD_CORO::coroutine_handle<>
-        await_suspend(
-            STD_CORO::coroutine_handle<> continuation) noexcept {
+        await_suspend(STD_CORO::coroutine_handle<> continuation) noexcept {
             // current coro started, caller becomes my continuation
             Base::_handle.promise()._continuation = continuation;
             return Base::_handle;
@@ -373,7 +371,7 @@ public:
         }
     };
     explicit Lazy(Handle coro) : _coro(coro) {}
-    Lazy(Lazy && other) : _coro(std::move(other._coro)) {
+    Lazy(Lazy&& other) : _coro(std::move(other._coro)) {
         other._coro = nullptr;
     }
 
@@ -383,7 +381,7 @@ public:
     // Bind an executor to a Lazy, and convert it to RescheduleLazy.
     // You can only call via on rvalue, i.e. a Lazy is not accessible after
     // via() called.
-    RescheduleLazy<T> via(Executor * ex)&& {
+    RescheduleLazy<T> via(Executor* ex) && {
         logicAssert(_coro.operator bool(),
                     "Lazy do not have a coroutine_handle");
         _coro.promise()._executor = ex;
@@ -394,7 +392,7 @@ public:
     //
     // Users shouldn't use `setEx` directly. `setEx` is designed
     // for internal purpose only. See uthread/Await.h/await for details.
-    Lazy<T> setEx(Executor * ex)&& {
+    Lazy<T> setEx(Executor* ex) && {
         logicAssert(_coro.operator bool(),
                     "Lazy do not have a coroutine_handle");
         _coro.promise()._executor = ex;
@@ -402,7 +400,7 @@ public:
     }
 
     template <typename F>
-    void start(F && callback) {
+    void start(F&& callback) {
         // callback should take a single Try<T> as parameter, return value will
         // be ignored. a detached coroutine will not suspend at initial/final
         // suspend point.
@@ -420,7 +418,7 @@ public:
         return ValueAwaiter(std::exchange(_coro, nullptr));
     }
 
-    auto coAwait(Executor * ex) {
+    auto coAwait(Executor* ex) {
         // derived lazy inherits executor
         _coro.promise()._executor = ex;
         return ValueAwaiter(std::exchange(_coro, nullptr));
@@ -432,7 +430,7 @@ private:
     friend class RescheduleLazy<T>;
 
     template <typename C>
-    friend typename std::decay_t<C>::ValueType syncAwait(C &&);
+    friend typename std::decay_t<C>::ValueType syncAwait(C&&);
 
     template <typename LazyType, typename IAlloc, typename OAlloc, bool Para>
     friend struct detail::CollectAllAwaiter;
@@ -493,7 +491,7 @@ private:
 public:
     RescheduleLazy(const RescheduleLazy&) = delete;
     RescheduleLazy& operator=(const RescheduleLazy&) = delete;
-    RescheduleLazy(RescheduleLazy && other)
+    RescheduleLazy(RescheduleLazy&& other)
         : _coro(std::exchange(other._coro, nullptr)) {}
 
     auto operator co_await() noexcept {
@@ -503,7 +501,7 @@ public:
     auto coAwaitTry() { return TryAwaiter(std::exchange(_coro, nullptr)); }
 
     template <typename F>
-    void start(F && callback) {
+    void start(F&& callback) {
         auto launchCoro = [](RescheduleLazy lazy,
                              std::decay_t<F> cb) -> detail::DetachedCoroutine {
             cb(std::move(co_await lazy.coAwaitTry()));
@@ -517,7 +515,7 @@ private:
     friend class Lazy<T>;
 
     template <typename C>
-    friend typename std::decay_t<C>::ValueType syncAwait(C &&);
+    friend typename std::decay_t<C>::ValueType syncAwait(C&&);
 
     template <typename LazyType, typename IAlloc, typename OAlloc, bool Para>
     friend struct detail::CollectAllAwaiter;

--- a/async_simple/coro/LazyHelper.h
+++ b/async_simple/coro/LazyHelper.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/coro/Sleep.h
+++ b/async_simple/coro/Sleep.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/coro/Task.h
+++ b/async_simple/coro/Task.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -45,8 +45,7 @@ public:
     struct Awaiter {
         constexpr bool await_ready() const noexcept { return true; }
         void await_suspend(
-            STD_CORO::coroutine_handle<> continuation) const noexcept {
-        }
+            STD_CORO::coroutine_handle<> continuation) const noexcept {}
         FL_INLINE T await_resume() noexcept {
             return std::move(task->stealValue());
         }
@@ -65,7 +64,7 @@ public:
             _value.~T();
         }
     }
-    Task(Task && other)
+    Task(Task&& other)
         : _coro(std::exchange(other._coro, nullptr)),
           _hasValue(std::exchange(other._hasValue, false)) {
         new (std::addressof(_value)) T(std::move(other._value));
@@ -77,12 +76,12 @@ public:
     Task& operator=(Task&&) = delete;
 
 public:
-    auto coAwait(Executor * ex) { return Awaiter(this); }
+    auto coAwait(Executor* ex) { return Awaiter(this); }
     auto operator co_await() { return Awaiter(this); }
 
 private:
     template <typename C>
-    FL_INLINE void setValue(C && v) noexcept {
+    FL_INLINE void setValue(C&& v) noexcept {
         new (std::addressof(_value)) T(std::forward<C>(v));
         _hasValue = true;
     }
@@ -111,30 +110,28 @@ public:
     struct Awaiter {
         constexpr bool await_ready() const noexcept { return true; }
         void await_suspend(
-            STD_CORO::coroutine_handle<> continuation) const noexcept {
-        }
+            STD_CORO::coroutine_handle<> continuation) const noexcept {}
         FL_INLINE void await_resume() const noexcept {}
         Awaiter() = default;
     };
 
 public:
     Task() = default;
-    Task(Task &&) = default;
+    Task(Task&&) = default;
 
     Task(const Task&) = delete;
     Task& operator=(const Task&) = delete;
     Task& operator=(Task&&) = delete;
 
 public:
-    auto coAwait(Executor * ex) { return Awaiter(); }
+    auto coAwait(Executor* ex) { return Awaiter(); }
     auto operator co_await() { return Awaiter(); }
 };
 
 namespace detail {
 
 struct TaskPromiseBase {
-    constexpr STD_CORO::suspend_never initial_suspend() const
-        noexcept {
+    constexpr STD_CORO::suspend_never initial_suspend() const noexcept {
         return {};
     }
     constexpr STD_CORO::suspend_never final_suspend() const noexcept {

--- a/async_simple/coro/Traits.h
+++ b/async_simple/coro/Traits.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/coro/Util.h
+++ b/async_simple/coro/Util.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,9 +39,7 @@ namespace detail {
 // better to use `Lazy::start()`.
 struct DetachedCoroutine {
     struct promise_type {
-        STD_CORO::suspend_never initial_suspend() noexcept {
-            return {};
-        }
+        STD_CORO::suspend_never initial_suspend() noexcept { return {}; }
         STD_CORO::suspend_never final_suspend() noexcept { return {}; }
         void return_void() noexcept {}
         void unhandled_exception() {

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -1145,8 +1145,7 @@ Lazy<int> getValue(A x) {
         ValueAwaiter(int v) : value(v) {}
 
         bool await_ready() { return false; }
-        void await_suspend(
-            STD_CORO::coroutine_handle<> continuation) noexcept {
+        void await_suspend(STD_CORO::coroutine_handle<> continuation) noexcept {
             std::thread([c = std::move(continuation)]() mutable {
                 c.resume();
             }).detach();

--- a/async_simple/coro/test/SleepTest.cpp
+++ b/async_simple/coro/test/SleepTest.cpp
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/coro/test/Time.h
+++ b/async_simple/coro/test/Time.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/coro/test/TraitsTest.cpp
+++ b/async_simple/coro/test/TraitsTest.cpp
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/coro/test/ViaCoroutineTest.cpp
+++ b/async_simple/coro/test/ViaCoroutineTest.cpp
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -56,8 +56,7 @@ public:
 class Awaiter {
 public:
     bool await_ready() noexcept { return false; }
-    bool await_suspend(
-        STD_CORO::coroutine_handle<> continuation) noexcept {
+    bool await_suspend(STD_CORO::coroutine_handle<> continuation) noexcept {
         return false;
     }
     void await_resume() noexcept {}

--- a/async_simple/executors/SimpleExecutor.h
+++ b/async_simple/executors/SimpleExecutor.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/executors/SimpleIOExecutor.h
+++ b/async_simple/executors/SimpleIOExecutor.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/executors/test/SimpleIOExecutorTest.cpp
+++ b/async_simple/executors/test/SimpleIOExecutorTest.cpp
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/experimental/coroutine.h
+++ b/async_simple/experimental/coroutine.h
@@ -309,7 +309,7 @@ struct suspend_always {
     void await_resume() const noexcept {}
 };
 
-}  // namespace std
+}  // namespace STD_CORO
 
 namespace std {
 

--- a/async_simple/test/FutureStateTest.cpp
+++ b/async_simple/test/FutureStateTest.cpp
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/test/FutureTest.cpp
+++ b/async_simple/test/FutureTest.cpp
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/test/TryTest.cpp
+++ b/async_simple/test/TryTest.cpp
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/test/dotest.cpp
+++ b/async_simple/test/dotest.cpp
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/test/unittest.h
+++ b/async_simple/test/unittest.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/uthread/Async.h
+++ b/async_simple/uthread/Async.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/uthread/Await.h
+++ b/async_simple/uthread/Await.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,7 +50,7 @@ decltype(auto) await(Executor* ex, Fn B::*fn, C* cls, Ts&&... ts) {
     auto f = p.getFuture().via(ex);
     auto lazy = [p = std::move(p), fn,
                  cls](Ts&&... ts) mutable -> coro::Lazy<> {
-        auto val = co_await(*cls.*fn)(ts...);
+        auto val = co_await (*cls.*fn)(ts...);
         p.setValue(std::move(val));
         co_return;
     };

--- a/async_simple/uthread/Collect.h
+++ b/async_simple/uthread/Collect.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/uthread/Latch.h
+++ b/async_simple/uthread/Latch.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/uthread/Uthread.h
+++ b/async_simple/uthread/Uthread.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/uthread/test/UthreadTest.cpp
+++ b/async_simple/uthread/test/UthreadTest.cpp
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -58,8 +58,7 @@ public:
         Awaiter(Executor* e, T v) : ex(e), value(v) {}
 
         bool await_ready() { return false; }
-        void await_suspend(
-            STD_CORO::coroutine_handle<> handle) noexcept {
+        void await_suspend(STD_CORO::coroutine_handle<> handle) noexcept {
             auto ctx = ex->checkout();
             std::thread([handle, e = ex, ctx]() mutable {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/async_simple/util/Condition.h
+++ b/async_simple/util/Condition.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/async_simple/util/ThreadPool.h
+++ b/async_simple/util/ThreadPool.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -274,9 +274,7 @@ inline bool ThreadPool::start() {
 
 inline void ThreadPool::stop(STOP_TYPE stopType) {
     if (STOP_THREAD_ONLY != stopType) {
-        {
-            _push = false;
-        }
+        { _push = false; }
     }
 
     if (STOP_AFTER_QUEUE_EMPTY == stopType) {

--- a/async_simple/util/test/ThreadPoolTest.cpp
+++ b/async_simple/util/test/ThreadPoolTest.cpp
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/demo_example/CountChar.cpp
+++ b/demo_example/CountChar.cpp
@@ -1,23 +1,23 @@
 /*
  * Copyright (c) 2022, Alibaba Group Holding Limited;
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "async_simple/coro/Lazy.h"
 #include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <string>
+#include "async_simple/coro/Lazy.h"
 
 using namespace async_simple::coro;
 

--- a/demo_example/async_echo_client.cpp
+++ b/demo_example/async_echo_client.cpp
@@ -21,7 +21,7 @@
 using asio::ip::tcp;
 
 async_simple::coro::Lazy<void> start(asio::io_context& io_context,
-                                    std::string host, std::string port) {
+                                     std::string host, std::string port) {
     auto [ec, socket] = co_await async_connect(io_context, host, port);
     if (ec) {
         std::cout << "Connect error: " << ec.message() << '\n';

--- a/demo_example/async_echo_server.cpp
+++ b/demo_example/async_echo_server.cpp
@@ -48,8 +48,8 @@ async_simple::coro::Lazy<void> session(tcp::socket sock) {
 }
 
 async_simple::coro::Lazy<void> start_server(asio::io_context& io_context,
-                                           unsigned short port,
-                                           async_simple::Executor* E) {
+                                            unsigned short port,
+                                            async_simple::Executor* E) {
     tcp::acceptor a(io_context, tcp::endpoint(tcp::v4(), port));
     std::cout << "Listen port " << port << " successfully.\n";
     for (;;) {
@@ -71,7 +71,8 @@ int main(int argc, char* argv[]) {
             io_context.run();
         });
         AsioExecutor executor(io_context);
-        async_simple::coro::syncAwait(start_server(io_context, 9980, &executor));
+        async_simple::coro::syncAwait(
+            start_server(io_context, 9980, &executor));
         thd.join();
     } catch (std::exception& e) {
         std::cerr << "Exception: " << e.what() << "\n";

--- a/demo_example/http/coroutine_http/http_client.cpp
+++ b/demo_example/http/coroutine_http/http_client.cpp
@@ -21,7 +21,7 @@
 using asio::ip::tcp;
 
 async_simple::coro::Lazy<void> start(asio::io_context& io_context,
-                                    std::string host, std::string port) {
+                                     std::string host, std::string port) {
     auto [ec, socket] = co_await async_connect(io_context, host, port);
     if (ec) {
         std::cout << "Connect error: " << ec.message() << '\n';


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

The old .clang-format was lost accidentally. Update one and use it to format codes.

## What is changing

Code Format.



