### PR TITLE
Enable Performance CI

### DIFF
--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -1,0 +1,53 @@
+name: Performance
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+permissions: write-all
+
+jobs:
+  benchmark:
+    name: Performance regression check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache Benchmark library
+        uses: actions/cache@v1
+        with:
+          path: ${{github.workspace}}/benchmarks
+          key: ${{ runner.os }}-googlebenchmark-v1.5.0
+      - name: Build benchmark
+        run: |
+           sudo apt install libaio-dev libgtest-dev -y
+           cd /usr/src/gtest
+           sudo mkdir build && cd build
+           sudo cmake .. && sudo make
+           sudo apt install libgmock-dev -y
+           sudo apt install libbenchmark-dev -y
+           cd ${{github.workspace}} && CXX=clang++ CC=clang cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+           cd ${{github.workspace}}/build/benchmarks && make -j
+      - name: Run benchmark
+        run: cd ${{github.workspace}}/build/benchmarks && ./Lazy.bench --benchmark_format=json | tee Lazy_benchmark_result.json
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: C++ Benchmark
+          tool: 'googlecpp'
+          output-file-path: ${{github.workspace}}/build/benchmarks/Lazy_benchmark_result.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-always: true
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: '50%'
+          comment-on-alert: true
+          fail-on-alert: true
+          gh-pages-branch: benchmark-monitoring
+          auto-push: true
+          benchmark-data-dir-path: benchmark-monitoring
+          alert-comment-cc-users: '@ChuanqiXu9, @RainMark, @qicosmos, @forever-hy'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

We need monitoring every commit and PR to avoid unimagined regressions.

## What is changing

We would receive an comment if the PR or commit cause a regression greater than 50%.

## Example

https://github.com/ChuanqiXu9/async_simple/pull/5#commitcomment-68189590

