### PR TITLE
Split Performance CI

### DIFF
--- a/.github/workflows/PerformanceCommit.yml
+++ b/.github/workflows/PerformanceCommit.yml
@@ -1,8 +1,6 @@
-name: Performance
+name: Performance for commit
 
 on:
-  pull_request:
-    branches: [ main ]
   push:
     branches: [ main ]
 
@@ -10,12 +8,11 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
-permissions: write-all
-
 jobs:
   benchmark:
     name: Performance regression check
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - uses: actions/checkout@v2
       - name: Cache Benchmark library
@@ -44,9 +41,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-always: true
           # Show alert with commit comment on detecting possible performance regression
-          alert-threshold: '50%'
-          comment-on-alert: true
-          fail-on-alert: true
+          alert-threshold: '150%'
+          fail-threshold: '200%'
           gh-pages-branch: benchmark-monitoring
           auto-push: true
           benchmark-data-dir-path: benchmark-monitoring

--- a/.github/workflows/PerformancePR.yml
+++ b/.github/workflows/PerformancePR.yml
@@ -1,0 +1,49 @@
+name: Performance for Pull Request
+
+on:
+  pull_request_target:
+    branches: [ main ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  benchmark:
+    name: Performance regression check
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache Benchmark library
+        uses: actions/cache@v1
+        with:
+          path: ${{github.workspace}}/benchmarks
+          key: ${{ runner.os }}-googlebenchmark-v1.5.0
+      - name: Build benchmark
+        run: |
+           sudo apt install libaio-dev libgtest-dev -y
+           cd /usr/src/gtest
+           sudo mkdir build && cd build
+           sudo cmake .. && sudo make
+           sudo apt install libgmock-dev -y
+           sudo apt install libbenchmark-dev -y
+           cd ${{github.workspace}} && CXX=clang++ CC=clang cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+           cd ${{github.workspace}}/build/benchmarks && make -j
+      - name: Run benchmark
+        run: cd ${{github.workspace}}/build/benchmarks && ./Lazy.bench --benchmark_format=json | tee Lazy_benchmark_result.json
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: C++ Benchmark
+          tool: 'googlecpp'
+          output-file-path: ${{github.workspace}}/build/benchmarks/Lazy_benchmark_result.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-always: false
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: '150%'
+          fail-threshold: '200%'
+          comment-on-alert: true
+          auto-push: false
+          gh-pages-branch: benchmark-monitoring
+          benchmark-data-dir-path: benchmark-monitoring

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build*
 _external/
 core.*
 \#*\#
+!.github
 !.gitignore
 !.clang-format
 *.so


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Due to the access control system, we need different actions for PR and commit. For example, we need record the performance of every commit. But we shouldn't record for every PR.
