### PR TITLE
[Compile Error]fix an error for gcc11

### DIFF
--- a/benchmarks/Lazy.bench.cpp
+++ b/benchmarks/Lazy.bench.cpp
@@ -50,7 +50,7 @@ void async_simple_Lazy_collectAll(benchmark::State& state) {
 
 void RescheduleLazy_chain(benchmark::State& state) {
     auto chain_starter = [&]() -> async_simple::coro::Lazy<int> {
-        co_return co_await lazy_fn<async_simple::coro::Lazy, 1000>()();
+        co_return co_await lazy_fn<async_simple::coro::Lazy, 948>()();
     };
     async_simple::executors::SimpleExecutor e(10);
     for ([[maybe_unused]] const auto& _ : state)


### PR DESCRIPTION
## Why
I compiled async_simple with gcc11, an compile error shows:
```
async_simple/benchmarks/Lazy.bench.cpp:23:58:   recursively required from ‘LazyType<int> lazy_fn<LazyType, N>::operator()() [with LazyType = async_simple::coro::Lazy; int N = 948]’
async_simple/benchmarks/Lazy.bench.cpp:23:58:   required from ‘LazyType<int> lazy_fn<LazyType, N>::operator()() [with LazyType = async_simple::coro::Lazy; int N = 949]’
async_simple/benchmarks/Lazy.bench.cpp:53:68:   required from here
async_simple/async_simple/coro/Lazy.h:130:15: fatal error: template instantiation depth exceeds maximum of 900 (use ‘-ftemplate-depth=’ to increase the maximum)
  130 |               typename = std::enable_if_t<std::is_convertible_v<V&&, T>>>
      |               ^~~~~~~~
compilation terminated.
```

This PR solves the compile error.



