### PR TITLE
Replace union to variant

### DIFF
--- a/async_simple/Executor.h
+++ b/async_simple/Executor.h
@@ -23,6 +23,7 @@
 #include <functional>
 #include <string>
 #include <thread>
+#include <variant>
 
 namespace async_simple {
 // Stat information for an executor.
@@ -62,8 +63,7 @@ class Executor {
 public:
     // Context is an indentification for the context where an executor
     // should run. See checkin/checkout for details.
-    using Context = void *;
-    static constexpr Context NULLCTX = nullptr;
+    using Context = std::variant<std::monostate, void *, int32_t>;
 
     // A time duration in microseconds.
     using Duration = std::chrono::duration<int64_t, std::micro>;
@@ -99,7 +99,7 @@ public:
     // implementation, then checkin(func, "Context") should schdule func to the
     // same "Context" as before.
     virtual size_t currentContextId() const { return 0; };
-    virtual Context checkout() { return NULLCTX; }
+    virtual Context checkout() { return {}; }
     virtual bool checkin(Func func, Context ctx, ScheduleOptions opts) {
         return schedule(std::move(func));
     }

--- a/async_simple/Executor.h
+++ b/async_simple/Executor.h
@@ -63,7 +63,7 @@ class Executor {
 public:
     // Context is an indentification for the context where an executor
     // should run. See checkin/checkout for details.
-    using Context = std::variant<std::monostate, void *, int32_t>;
+    using Context = std::variant<std::monostate, void *, int64_t>;
 
     // A time duration in microseconds.
     using Duration = std::chrono::duration<int64_t, std::micro>;

--- a/async_simple/FutureState.h
+++ b/async_simple/FutureState.h
@@ -115,7 +115,7 @@ public:
           _attached(0),
           _continuationRef(0),
           _executor(nullptr),
-          _context(Executor::NULLCTX),
+          _context{},
           _promiseRef(0),
           _forceSched(false) {}
     ~FutureState() {}
@@ -274,7 +274,7 @@ private:
             ContinuationReference guardForException(this);
             try {
                 bool ret;
-                if (Executor::NULLCTX == _context) {
+                if (_context.index() == 0) {
                     ret = _executor->schedule(
                         [fsRef = std::move(guard)]() mutable {
                             auto ref = std::move(fsRef);

--- a/async_simple/Try.h
+++ b/async_simple/Try.h
@@ -39,8 +39,7 @@ public:
     Try() : _result{} {}
     ~Try() { destroy(); }
 
-    Try(Try<T>&& other) : _result(std::move(other._result)) {
-    }
+    Try(Try<T>&& other) : _result(std::move(other._result)) {}
     template <typename T2 = T>
     Try(std::enable_if_t<std::is_same<Unit, T2>::value, const Try<void>&>
             other) {
@@ -73,8 +72,7 @@ public:
 
     Try(const T& val) : _result(val) {}
     Try(T&& val) : _result(std::move(val)) {}
-    Try(std::exception_ptr error)
-        : _result(error) {}
+    Try(std::exception_ptr error) : _result(error) {}
 
 private:
     Try(const Try&) = delete;
@@ -108,8 +106,7 @@ public:
         _result = error;
     }
     std::exception_ptr getException() {
-        logicAssert(_result.index() == 2,
-                    "Try object do not has an error");
+        logicAssert(_result.index() == 2, "Try object do not has an error");
         return std::get<2>(_result);
     }
 
@@ -126,9 +123,7 @@ private:
         }
     }
 
-    void destroy() {
-        _result = {};
-    }
+    void destroy() { _result = {}; }
 
 private:
     std::variant<std::monostate, T, std::exception_ptr> _result;

--- a/async_simple/coro/CoAwait.h
+++ b/async_simple/coro/CoAwait.h
@@ -43,7 +43,7 @@ class ViaCoroutine {
 public:
     struct promise_type {
         struct FinalAwaiter;
-        promise_type(Executor* ex) : _ex(ex), _ctx(Executor::NULLCTX) {}
+        promise_type(Executor* ex) : _ex(ex), _ctx{} {}
         ViaCoroutine get_return_object() noexcept;
         void return_void() noexcept {}
         void unhandled_exception() const noexcept { assert(false); }

--- a/async_simple/coro/test/ViaCoroutineTest.cpp
+++ b/async_simple/coro/test/ViaCoroutineTest.cpp
@@ -45,7 +45,7 @@ public:
     }
     bool checkin(Func func, Context ctx, ScheduleOptions opts) override {
         // -1 is invalid ctx for SimpleExecutor
-        if (ctx == (void*)-1) {
+        if (ctx.index() == 0) {
             return false;
         }
         check--;

--- a/async_simple/executors/SimpleExecutor.cpp
+++ b/async_simple/executors/SimpleExecutor.cpp
@@ -34,18 +34,17 @@ SimpleExecutor::~SimpleExecutor() {
 }
 
 SimpleExecutor::Context SimpleExecutor::checkout() {
-    // avoid CurrentId equal to NULLCTX
-    return reinterpret_cast<Context>(_pool.getCurrentId() | kContextMask);
+    return _pool.getCurrentId() | kContextMask;
 }
 
 bool SimpleExecutor::checkin(Func func, Context ctx, ScheduleOptions opts) {
-    int64_t id = reinterpret_cast<int64_t>(ctx);
-    auto prompt = _pool.getCurrentId() == (id & (~kContextMask)) && opts.prompt;
+    int64_t id = std::get<2>(ctx) & (~kContextMask);
+    auto prompt = _pool.getCurrentId() == id && opts.prompt;
     if (prompt) {
         func();
         return true;
     }
-    return _pool.scheduleById(std::move(func), id & (~kContextMask)) ==
+    return _pool.scheduleById(std::move(func), id) ==
            util::ThreadPool::ERROR_NONE;
 }
 

--- a/async_simple/executors/test/CMakeLists.txt
+++ b/async_simple/executors/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 file(GLOB executor_test_src "*.cpp")
 add_executable(async_simple_executor_test ${executor_test_src} ${PROJECT_SOURCE_DIR}/async_simple/test/dotest.cpp)
 
-target_link_libraries(async_simple_executor_test async_simple ${deplibs} ${testdeplibs})
+target_link_libraries(async_simple_executor_test async_simple -pthread ${deplibs} ${testdeplibs})
 
 add_test(NAME run_async_simple_executor_test COMMAND async_simple_executor_test)
 

--- a/async_simple/uthread/test/UthreadTest.cpp
+++ b/async_simple/uthread/test/UthreadTest.cpp
@@ -149,7 +149,7 @@ public:
 
 public:
     bool currentThreadInExecutor() const override { return true; }
-    Context checkout() override { return NULLCTX; }
+    Context checkout() override { return {}; }
     bool checkin(Func func, Context ctx, ScheduleOptions opts) override {
         return schedule(std::move(func));
     }


### PR DESCRIPTION
## Why

Use std::variant avoid undefined behavior of visit inactive union member.
For Close #59 
