### PR TITLE
fix benchmark uthread detect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,13 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     list(APPEND CXX_FLAGS "-fsanitize=address")
 endif()
 
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") # uname -s
+  if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64|aarch64") # uname -p
+    set(UTHREAD ON)
+    message("-- Uthread on")
+  endif()
+endif()
+
 string(REPLACE ";" " " CMAKE_CXX_FLAGS "${CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")

--- a/async_simple/CMakeLists.txt
+++ b/async_simple/CMakeLists.txt
@@ -1,16 +1,12 @@
 file(GLOB coro_src "coro/*.cpp")
 file(GLOB executors_src "executors/*.cpp")
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") # uname -s
+if(UTHREAD)
   file(GLOB uthread_src "uthread/internal/*.cc")
-  if ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64") # uname -p
+  if ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
     file(GLOB uthread_asm_src "uthread/internal/*arm64_aapcs_elf*")
-    set(UTHREAD ON)
   elseif ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
     file(GLOB uthread_asm_src "uthread/internal/*x86_64_sysv_elf*")
-    set(UTHREAD ON)
-  else()
-    message(STATUS "Uthread Unsupported Target: ${CMAKE_SYSTEM_PROCESSOR}")
   endif()
 endif()
 


### PR DESCRIPTION
Signed-off-by: Rain Mark <rain.by.zhou@gmail.com>

<!-- Thank you for your contribution! -->

## Why

current ci not run uthread benchmark

move uthread detect to top cmake file to make sure UTHREAD variable can be used in benchmark directory


