### PR TITLE
Enable to use coroutine components under std directly

### DIFF
--- a/async_simple/Executor.h
+++ b/async_simple/Executor.h
@@ -168,7 +168,7 @@ public:
     }
 
     template <typename PromiseType>
-    void await_suspend(STD_CORO::coroutine_handle<PromiseType> continuation) {
+    void await_suspend(std::coroutine_handle<PromiseType> continuation) {
         std::function<void()> func = [c = continuation]() mutable {
             c.resume();
         };
@@ -204,7 +204,7 @@ public:
     bool await_ready() const noexcept { return false; }
 
     template <typename PromiseType>
-    void await_suspend(STD_CORO::coroutine_handle<PromiseType> continuation) {
+    void await_suspend(std::coroutine_handle<PromiseType> continuation) {
         std::function<void()> func = [c = continuation]() mutable {
             c.resume();
         };

--- a/async_simple/coro/CoAwait.h
+++ b/async_simple/coro/CoAwait.h
@@ -48,7 +48,7 @@ public:
         void return_void() noexcept {}
         void unhandled_exception() const noexcept { assert(false); }
 
-        STD_CORO::suspend_always initial_suspend() const noexcept { return {}; }
+        std::suspend_always initial_suspend() const noexcept { return {}; }
         FinalAwaiter final_suspend() noexcept { return FinalAwaiter(_ctx); }
 
         struct FinalAwaiter {
@@ -56,8 +56,7 @@ public:
             bool await_ready() const noexcept { return false; }
 
             template <typename PromiseType>
-            auto await_suspend(
-                STD_CORO::coroutine_handle<PromiseType> h) noexcept {
+            auto await_suspend(std::coroutine_handle<PromiseType> h) noexcept {
                 auto& pr = h.promise();
                 // promise will remain valid across final_suspend point
                 if (pr._ex) {
@@ -75,11 +74,11 @@ public:
         };
 
         Executor* _ex;
-        STD_CORO::coroutine_handle<> _continuation;
+        std::coroutine_handle<> _continuation;
         Executor::Context _ctx;
     };
 
-    ViaCoroutine(STD_CORO::coroutine_handle<promise_type> coro) : _coro(coro) {}
+    ViaCoroutine(std::coroutine_handle<promise_type> coro) : _coro(coro) {}
     ~ViaCoroutine() {
         if (_coro) {
             _coro.destroy();
@@ -103,8 +102,8 @@ public:
             pr._ex->checkin(func, pr._ctx);
         }
     }
-    STD_CORO::coroutine_handle<> getWrappedContinuation(
-        STD_CORO::coroutine_handle<> continuation) {
+    std::coroutine_handle<> getWrappedContinuation(
+        std::coroutine_handle<> continuation) {
         // do not call this method on a moved ViaCoroutine,
         assert(_coro);
         auto& pr = _coro.promise();
@@ -116,13 +115,12 @@ public:
     }
 
 private:
-    STD_CORO::coroutine_handle<promise_type> _coro;
+    std::coroutine_handle<promise_type> _coro;
 };
 
 inline ViaCoroutine ViaCoroutine::promise_type::get_return_object() noexcept {
     return ViaCoroutine(
-        STD_CORO::coroutine_handle<ViaCoroutine::promise_type>::from_promise(
-            *this));
+        std::coroutine_handle<ViaCoroutine::promise_type>::from_promise(*this));
 }
 
 // used by co_await non-Lazy object
@@ -134,7 +132,7 @@ struct [[nodiscard]] ViaAsyncAwaiter {
           _awaiter(detail::getAwaiter(std::forward<Awaitable>(awaitable))),
           _viaCoroutine(ViaCoroutine::create(ex)) {}
 
-    using HandleType = STD_CORO::coroutine_handle<>;
+    using HandleType = std::coroutine_handle<>;
     using AwaitSuspendResultType =
         decltype(std::declval<Awaiter&>().await_suspend(
             std::declval<HandleType>()));

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -80,9 +80,9 @@ struct CollectAnyAwaiter {
                (_result && _result->_idx != static_cast<size_t>(-1));
     }
 
-    void await_suspend(STD_CORO::coroutine_handle<> continuation) {
+    void await_suspend(std::coroutine_handle<> continuation) {
         auto promise_type =
-            STD_CORO::coroutine_handle<LazyPromiseBase>::from_address(
+            std::coroutine_handle<LazyPromiseBase>::from_address(
                 continuation.address())
                 .promise();
         auto executor = promise_type._executor;
@@ -156,9 +156,9 @@ struct CollectAllAwaiter {
     CollectAllAwaiter& operator=(const CollectAllAwaiter&) = delete;
 
     inline bool await_ready() const noexcept { return _input.empty(); }
-    inline void await_suspend(STD_CORO::coroutine_handle<> continuation) {
+    inline void await_suspend(std::coroutine_handle<> continuation) {
         auto promise_type =
-            STD_CORO::coroutine_handle<LazyPromiseBase>::from_address(
+            std::coroutine_handle<LazyPromiseBase>::from_address(
                 continuation.address())
                 .promise();
         auto executor = promise_type._executor;

--- a/async_simple/coro/Event.h
+++ b/async_simple/coro/Event.h
@@ -51,7 +51,7 @@ public:
             return nullptr;
             // return nullptr instead of noop_coroutine could save one time
             // for accessing the memory.
-            // return STD_CORO::noop_coroutine();
+            // return std::noop_coroutine();
         }
     }
     [[nodiscard]] size_t downCount(size_t n = 1) {

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -64,7 +64,7 @@ public:
     struct FinalAwaiter {
         bool await_ready() const noexcept { return false; }
         template <typename PromiseType>
-        auto await_suspend(STD_CORO::coroutine_handle<PromiseType> h) noexcept {
+        auto await_suspend(std::coroutine_handle<PromiseType> h) noexcept {
             return h.promise()._continuation;
         }
         void await_resume() noexcept {}
@@ -73,7 +73,7 @@ public:
     struct YieldAwaiter {
         YieldAwaiter(Executor* executor) : _executor(executor) {}
         bool await_ready() const noexcept { return false; }
-        void await_suspend(STD_CORO::coroutine_handle<> handle) {
+        void await_suspend(std::coroutine_handle<> handle) {
             std::function<void()> func = [h = std::move(handle)]() mutable {
                 h.resume();
             };
@@ -88,7 +88,7 @@ public:
 public:
     LazyPromiseBase() : _executor(nullptr) {}
     // Lazily started, coroutine will not execute until first resume() is called
-    STD_CORO::suspend_always initial_suspend() noexcept { return {}; }
+    std::suspend_always initial_suspend() noexcept { return {}; }
     FinalAwaiter final_suspend() noexcept { return {}; }
 
     template <typename Awaitable>
@@ -104,7 +104,7 @@ public:
 
 public:
     Executor* _executor;
-    STD_CORO::coroutine_handle<> _continuation;
+    std::coroutine_handle<> _continuation;
 };
 
 template <typename T>
@@ -341,8 +341,8 @@ public:
         using Base = detail::LazyAwaiterBase<T>;
         AwaiterBase(Handle coro) : Base(coro) {}
 
-        __attribute__((__always_inline__)) STD_CORO::coroutine_handle<>
-        await_suspend(STD_CORO::coroutine_handle<> continuation) noexcept {
+        __attribute__((__always_inline__)) std::coroutine_handle<>
+        await_suspend(std::coroutine_handle<> continuation) noexcept {
             // current coro started, caller becomes my continuation
             Base::_handle.promise()._continuation = continuation;
             return Base::_handle;

--- a/async_simple/coro/Util.h
+++ b/async_simple/coro/Util.h
@@ -38,8 +38,8 @@ namespace detail {
 // better to use `Lazy::start()`.
 struct DetachedCoroutine {
     struct promise_type {
-        STD_CORO::suspend_never initial_suspend() noexcept { return {}; }
-        STD_CORO::suspend_never final_suspend() noexcept { return {}; }
+        std::suspend_never initial_suspend() noexcept { return {}; }
+        std::suspend_never final_suspend() noexcept { return {}; }
         void return_void() noexcept {}
         void unhandled_exception() {
             try {

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -75,8 +75,7 @@ public:
             ValueAwaiter(LazyTest* t) : test(t), value(0) {}
 
             bool await_ready() { return false; }
-            void await_suspend(
-                STD_CORO::coroutine_handle<> continuation) noexcept {
+            void await_suspend(std::coroutine_handle<> continuation) noexcept {
                 test->applyValue(
                     [this, c = std::move(continuation)](int v) mutable {
                         value = v;
@@ -98,8 +97,7 @@ public:
             ValueAwaiter() {}
 
             bool await_ready() { return false; }
-            void await_suspend(
-                STD_CORO::coroutine_handle<> continuation) noexcept {
+            void await_suspend(std::coroutine_handle<> continuation) noexcept {
                 std::thread([c = continuation]() mutable {
                     c.resume();
                 }).detach();
@@ -119,8 +117,7 @@ public:
             ValueAwaiter(T v) : value(v) {}
 
             bool await_ready() { return false; }
-            void await_suspend(
-                STD_CORO::coroutine_handle<> continuation) noexcept {
+            void await_suspend(std::coroutine_handle<> continuation) noexcept {
                 std::thread([c = continuation]() mutable {
                     c.resume();
                 }).detach();
@@ -141,8 +138,7 @@ public:
             ValueAwaiter(int v) : value(v) {}
 
             bool await_ready() { return false; }
-            void await_suspend(
-                STD_CORO::coroutine_handle<> continuation) noexcept {
+            void await_suspend(std::coroutine_handle<> continuation) noexcept {
                 std::thread([c = continuation]() mutable {
                     std::this_thread::sleep_for(
                         std::chrono::microseconds(rand() % 1000 + 1));
@@ -162,8 +158,7 @@ public:
         struct ValueAwaiter {
             ValueAwaiter() {}
             bool await_ready() { return false; }
-            void await_suspend(
-                STD_CORO::coroutine_handle<> continuation) noexcept {
+            void await_suspend(std::coroutine_handle<> continuation) noexcept {
                 std::thread([c = continuation]() mutable {
                     std::this_thread::sleep_for(
                         std::chrono::microseconds(rand() % 1000000 + 1));
@@ -1129,7 +1124,7 @@ Lazy<int> getValue(A x) {
         ValueAwaiter(int v) : value(v) {}
 
         bool await_ready() { return false; }
-        void await_suspend(STD_CORO::coroutine_handle<> continuation) noexcept {
+        void await_suspend(std::coroutine_handle<> continuation) noexcept {
             std::thread([c = std::move(continuation)]() mutable {
                 c.resume();
             }).detach();

--- a/async_simple/coro/test/ViaCoroutineTest.cpp
+++ b/async_simple/coro/test/ViaCoroutineTest.cpp
@@ -56,7 +56,7 @@ public:
 class Awaiter {
 public:
     bool await_ready() noexcept { return false; }
-    bool await_suspend(STD_CORO::coroutine_handle<> continuation) noexcept {
+    bool await_suspend(std::coroutine_handle<> continuation) noexcept {
         return false;
     }
     void await_resume() noexcept {}

--- a/async_simple/uthread/test/UthreadTest.cpp
+++ b/async_simple/uthread/test/UthreadTest.cpp
@@ -57,7 +57,7 @@ public:
         Awaiter(Executor* e, T v) : ex(e), value(v) {}
 
         bool await_ready() { return false; }
-        void await_suspend(STD_CORO::coroutine_handle<> handle) noexcept {
+        void await_suspend(std::coroutine_handle<> handle) noexcept {
             auto ctx = ex->checkout();
             std::thread([handle, e = ex, ctx]() mutable {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -315,7 +315,7 @@ struct Awaiter {
     Awaiter(Executor* e, T v) : ex(e), value(v) {}
 
     bool await_ready() { return false; }
-    void await_suspend(STD_CORO::coroutine_handle<> handle) noexcept {
+    void await_suspend(std::coroutine_handle<> handle) noexcept {
         auto ctx = ex->checkout();
         std::thread([handle, e = ex, ctx]() mutable {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/demo_example/asio_util.hpp
+++ b/demo_example/asio_util.hpp
@@ -74,7 +74,7 @@ public:
                     asio::ip::tcp::socket socket)
         : acceptor_(acceptor), socket_(std::move(socket)) {}
     bool await_ready() const noexcept { return false; }
-    void await_suspend(STD_CORO::coroutine_handle<> handle) {
+    void await_suspend(std::coroutine_handle<> handle) {
         acceptor_.async_accept([this, handle](auto ec, auto socket) mutable {
             ec_ = ec;
             socket_ = std::move(socket);
@@ -108,7 +108,7 @@ public:
         : socket_(socket), buffer_(buffer) {}
     bool await_ready() { return false; }
     auto await_resume() { return std::make_pair(ec_, size_); }
-    void await_suspend(STD_CORO::coroutine_handle<> handle) {
+    void await_suspend(std::coroutine_handle<> handle) {
         socket_.async_read_some(std::move(buffer_),
                                 [this, handle](auto ec, auto size) mutable {
                                     ec_ = ec;
@@ -141,7 +141,7 @@ public:
         : socket_(socket), buffer_(buffer) {}
     bool await_ready() { return false; }
     auto await_resume() { return std::make_pair(ec_, size_); }
-    void await_suspend(STD_CORO::coroutine_handle<> handle) {
+    void await_suspend(std::coroutine_handle<> handle) {
         asio::async_read(socket_, buffer_,
                          [this, handle](auto ec, auto size) mutable {
                              ec_ = ec;
@@ -175,7 +175,7 @@ public:
         : socket_(socket), buffer_(buffer), delim_(delim) {}
     bool await_ready() { return false; }
     auto await_resume() { return std::make_pair(ec_, size_); }
-    void await_suspend(STD_CORO::coroutine_handle<> handle) {
+    void await_suspend(std::coroutine_handle<> handle) {
         asio::async_read_until(socket_, buffer_, delim_,
                                [this, handle](auto ec, auto size) mutable {
                                    ec_ = ec;
@@ -210,7 +210,7 @@ public:
         : socket_(socket), buffer_(std::move(buffer)) {}
     bool await_ready() { return false; }
     auto await_resume() { return std::make_pair(ec_, size_); }
-    void await_suspend(STD_CORO::coroutine_handle<> handle) {
+    void await_suspend(std::coroutine_handle<> handle) {
         asio::async_write(socket_, std::move(buffer_),
                           [this, handle](auto ec, auto size) mutable {
                               ec_ = ec;
@@ -242,7 +242,7 @@ public:
                    const std::string &host, const std::string &port)
         : io_context_(io_context), socket_(socket), host_(host), port_(port) {}
     bool await_ready() const noexcept { return false; }
-    void await_suspend(STD_CORO::coroutine_handle<> handle) {
+    void await_suspend(std::coroutine_handle<> handle) {
         asio::ip::tcp::resolver resolver(io_context_);
         auto endpoints = resolver.resolve(host_, port_);
         asio::async_connect(socket_, endpoints,


### PR DESCRIPTION
We could use coroutine components under std directly by using
experimental ones in std namespace. So the code would be cleaner.