### PR TITLE
Support windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ endif()
 set(testdeplibs)
 list(APPEND testdeplibs ${GTEST_LIBRARIES})
 list(APPEND testdeplibs ${GMOCK_LIBRARIES})
+list(APPEND testdeplibs ${CMAKE_THREAD_LIBS_INIT})
 
 if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     if(CMAKE_BUILD_BITS EQUAL 32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ enable_testing()
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 message(STATUS "CMAKE_MODULE_PATH: ${CMAKE_MODULE_PATH}")
 
+find_package(Threads)
 find_package(Aio)
 find_package(GMock REQUIRED)
 find_package(GTest REQUIRED)
@@ -42,17 +43,25 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 # set CXXFALGS
-set(CXX_FLAGS
-    -std=c++20
-    -D_GLIBCXX_USE_CXX11_ABI=1
-    -Wno-deprecated-register
-    -D_FILE_OFFSET_BITS=64
-    -fPIC
-    -Wall
-    -Werror
-    -D__STDC_LIMIT_MACROS
-    -g
-    )
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    set(CXX_FLAGS
+        /std:c++20
+        /await:strict
+        /EHa
+        )
+else()
+    set(CXX_FLAGS
+        -std=c++20
+        -D_GLIBCXX_USE_CXX11_ABI=1
+        -Wno-deprecated-register
+        -D_FILE_OFFSET_BITS=64
+        -fPIC
+        -Wall
+        -Werror
+        -D__STDC_LIMIT_MACROS
+        -g
+        )
+endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     list(APPEND CXX_FLAGS "-fcoroutines")
@@ -67,24 +76,27 @@ set(HEADERS_PATH
 include_directories(${HEADERS_PATH})
 
 set(deplibs)
+list(APPEND deplibs ${CMAKE_THREAD_LIBS_INIT})
 if(LIBAIO_LIBRARIES)
     list(APPEND deplibs ${LIBAIO_LIBRARIES})
 endif()
-list(APPEND deplibs pthread)
+
 set(testdeplibs)
 list(APPEND testdeplibs ${GTEST_LIBRARIES})
 list(APPEND testdeplibs ${GMOCK_LIBRARIES})
 
-if(CMAKE_BUILD_BITS EQUAL 32)
-    message("-- Use flag -m32")
-    list(APPEND CXX_FLAGS "-m32")
-    list(APPEND CXX_FLAGS "-DTARGET_32")
-    list(APPEND deplibs "-m32")
-else()
-    message("-- Use flag -m64")
-    list(APPEND CXX_FLAGS "-m64")
-    list(APPEND CXX_FLAGS "-DTARGET_64")
-    #list(APPEND deplibs "-m64")
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    if(CMAKE_BUILD_BITS EQUAL 32)
+        message("-- Use flag -m32")
+        list(APPEND CXX_FLAGS "-m32")
+        list(APPEND CXX_FLAGS "-DTARGET_32")
+        list(APPEND deplibs "-m32")
+    else()
+        message("-- Use flag -m64")
+        list(APPEND CXX_FLAGS "-m64")
+        list(APPEND CXX_FLAGS "-DTARGET_64")
+        #list(APPEND deplibs "-m64")
+    endif()
 endif()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -100,8 +112,14 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") # uname -s
 endif()
 
 string(REPLACE ";" " " CMAKE_CXX_FLAGS "${CXX_FLAGS}")
-set(CMAKE_CXX_FLAGS_DEBUG "-O0")
-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    set(CMAKE_CXX_FLAGS_DEBUG "-O0")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+else()
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+endif()
 
 add_subdirectory(async_simple)
 add_subdirectory(demo_example)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,9 +99,11 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     endif()
 endif()
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    message("-- Use flag -fsanitize=address")
-    list(APPEND CXX_FLAGS "-fsanitize=address")
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        message("-- Use flag -fsanitize=address")
+        list(APPEND CXX_FLAGS "-fsanitize=address")
+    endif()
 endif()
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") # uname -s

--- a/async_simple/CMakeLists.txt
+++ b/async_simple/CMakeLists.txt
@@ -30,15 +30,15 @@ if(UTHREAD)
   list(APPEND SRCS ${uthread_asm_src})
 endif()
 
-add_library(async_simple_static STATIC ${SRCS})
-add_library(async_simple SHARED ${SRCS})
+add_library(async_simple STATIC ${SRCS})
+add_library(async_simple_shared SHARED ${SRCS})
 target_link_libraries(async_simple ${deplibs})
-target_link_libraries(async_simple_static ${deplibs})
+target_link_libraries(async_simple_shared ${deplibs})
 
-set_target_properties(async_simple_static PROPERTIES OUTPUT_NAME "async_simple")
+#set_target_properties(async_simple_static PROPERTIES OUTPUT_NAME "async_simple")
 
 install(TARGETS async_simple DESTINATION lib/)
-install(TARGETS async_simple_static DESTINATION lib/)
+#install(TARGETS async_simple_static DESTINATION lib/)
 
 install(FILES ${headers} DESTINATION include/async_simple)
 install(FILES ${coro_header} DESTINATION include/async_simple/coro)

--- a/async_simple/CMakeLists.txt
+++ b/async_simple/CMakeLists.txt
@@ -30,12 +30,12 @@ if(UTHREAD)
   list(APPEND SRCS ${uthread_asm_src})
 endif()
 
-add_library(async_simple STATIC ${SRCS})
-add_library(async_simple_shared SHARED ${SRCS})
+add_library(async_simple_static STATIC ${SRCS})
+add_library(async_simple SHARED ${SRCS})
 target_link_libraries(async_simple ${deplibs})
-target_link_libraries(async_simple_shared ${deplibs})
+target_link_libraries(async_simple_static ${deplibs})
 
-#set_target_properties(async_simple_static PROPERTIES OUTPUT_NAME "async_simple")
+set_target_properties(async_simple_static PROPERTIES OUTPUT_NAME "async_simple")
 
 install(TARGETS async_simple DESTINATION lib/)
 #install(TARGETS async_simple_static DESTINATION lib/)

--- a/async_simple/Common.h
+++ b/async_simple/Common.h
@@ -18,12 +18,16 @@
 
 #include <stdexcept>
 
-#ifdef _WIN32
-#define __builtin_expect(EXP, C) (EXP)
+#if defined(__clang__) && __clang_major__ < 12
+#define LIKELY
+#define UNLIKELY
+#else
+#define LIKELY [[likely]]
+#define UNLIKELY [[unlikely]]
 #endif
 
 #ifdef _WIN32
-#define AS_INLINE inline
+#define AS_INLINE
 #else
 #define AS_INLINE __attribute__((__always_inline__)) inline
 #endif
@@ -37,13 +41,7 @@ namespace async_simple {
 // there is a bug in the user code.
 inline void logicAssert(bool x, const char* errorMsg) {
     if (x)
-#if defined(__clang__) && __clang_major__ < 12
-    {
-        return;
-    }
-#else
-        [[likely]] { return; }
-#endif
+        LIKELY { return; }
     throw std::logic_error(errorMsg);
 }
 

--- a/async_simple/Common.h
+++ b/async_simple/Common.h
@@ -22,9 +22,6 @@
 #define __builtin_expect(EXP, C) (EXP)
 #endif
 
-#define FL_LIKELY(x) __builtin_expect((x), 1)
-#define FL_UNLIKELY(x) __builtin_expect((x), 0)
-
 #ifdef _WIN32
 #define FL_INLINE inline
 #else
@@ -39,7 +36,7 @@ namespace async_simple {
 // a bug in the library. If logicAssert fails, it means
 // there is a bug in the user code.
 inline void logicAssert(bool x, const char* errorMsg) {
-    if (FL_LIKELY(x)) {
+    if (x) [[likely]] {
         return;
     }
     throw std::logic_error(errorMsg);

--- a/async_simple/Common.h
+++ b/async_simple/Common.h
@@ -37,11 +37,13 @@ namespace async_simple {
 // there is a bug in the user code.
 inline void logicAssert(bool x, const char* errorMsg) {
     if (x)
-    #if defined(__clang__) && __clang_major__ < 12
-        { return; }
-    #else
+#if defined(__clang__) && __clang_major__ < 12
+    {
+        return;
+    }
+#else
         [[likely]] { return; }
-    #endif
+#endif
     throw std::logic_error(errorMsg);
 }
 

--- a/async_simple/Common.h
+++ b/async_simple/Common.h
@@ -18,10 +18,18 @@
 
 #include <stdexcept>
 
+#ifdef _WIN32
+#define __builtin_expect(EXP, C) (EXP)
+#endif
+
 #define FL_LIKELY(x) __builtin_expect((x), 1)
 #define FL_UNLIKELY(x) __builtin_expect((x), 0)
 
+#ifdef _WIN32
+#define FL_INLINE inline
+#else
 #define FL_INLINE __attribute__((__always_inline__)) inline
+#endif
 
 namespace async_simple {
 // Different from assert, logicAssert is meaningful in

--- a/async_simple/Common.h
+++ b/async_simple/Common.h
@@ -37,7 +37,11 @@ namespace async_simple {
 // there is a bug in the user code.
 inline void logicAssert(bool x, const char* errorMsg) {
     if (x)
+    #if defined(__clang__) && __clang_major__ < 12
+        { return; }
+    #else
         [[likely]] { return; }
+    #endif
     throw std::logic_error(errorMsg);
 }
 

--- a/async_simple/Common.h
+++ b/async_simple/Common.h
@@ -23,9 +23,9 @@
 #endif
 
 #ifdef _WIN32
-#define FL_INLINE inline
+#define AS_INLINE inline
 #else
-#define FL_INLINE __attribute__((__always_inline__)) inline
+#define AS_INLINE __attribute__((__always_inline__)) inline
 #endif
 
 namespace async_simple {

--- a/async_simple/Common.h
+++ b/async_simple/Common.h
@@ -36,9 +36,8 @@ namespace async_simple {
 // a bug in the library. If logicAssert fails, it means
 // there is a bug in the user code.
 inline void logicAssert(bool x, const char* errorMsg) {
-    if (x) [[likely]] {
-        return;
-    }
+    if (x)
+        [[likely]] { return; }
     throw std::logic_error(errorMsg);
 }
 

--- a/async_simple/FutureState.h
+++ b/async_simple/FutureState.h
@@ -140,21 +140,21 @@ public:
         return (state & allow) != detail::State();
     }
 
-    FL_INLINE void attachOne() {
+    AS_INLINE void attachOne() {
         _attached.fetch_add(1, std::memory_order_relaxed);
     }
-    FL_INLINE void detachOne() {
+    AS_INLINE void detachOne() {
         auto old = _attached.fetch_sub(1, std::memory_order_relaxed);
         assert(old >= 1u);
         if (old == 1) {
             delete this;
         }
     }
-    FL_INLINE void attachPromise() {
+    AS_INLINE void attachPromise() {
         _promiseRef.fetch_add(1, std::memory_order_relaxed);
         attachOne();
     }
-    FL_INLINE void detachPromise() {
+    AS_INLINE void detachPromise() {
         auto old = _promiseRef.fetch_sub(1, std::memory_order_relaxed);
         assert(old >= 1u);
         if (!hasResult() && old == 1) {

--- a/async_simple/FutureState.h
+++ b/async_simple/FutureState.h
@@ -140,21 +140,21 @@ public:
         return (state & allow) != detail::State();
     }
 
-    inline __attribute__((__always_inline__)) void attachOne() {
+    FL_INLINE void attachOne() {
         _attached.fetch_add(1, std::memory_order_relaxed);
     }
-    inline __attribute__((__always_inline__)) void detachOne() {
+    FL_INLINE void detachOne() {
         auto old = _attached.fetch_sub(1, std::memory_order_relaxed);
         assert(old >= 1u);
         if (old == 1) {
             delete this;
         }
     }
-    inline __attribute__((__always_inline__)) void attachPromise() {
+    FL_INLINE void attachPromise() {
         _promiseRef.fetch_add(1, std::memory_order_relaxed);
         attachOne();
     }
-    inline __attribute__((__always_inline__)) void detachPromise() {
+    FL_INLINE void detachPromise() {
         auto old = _promiseRef.fetch_sub(1, std::memory_order_relaxed);
         assert(old >= 1u);
         if (!hasResult() && old == 1) {
@@ -168,8 +168,8 @@ public:
     }
 
 public:
-    Try<T>& getTry() noexcept { return _try; }
-    const Try<T>& getTry() const noexcept { return _try; }
+    Try<T>& getTry() noexcept { return _try_value; }
+    const Try<T>& getTry() const noexcept { return _try_value; }
 
     void setExecutor(Executor* ex) { _executor = ex; }
 
@@ -196,7 +196,7 @@ public:
     //  ONLY_CONTINUATION: future.thenImpl called
     void setResult(Try<T>&& value) {
         logicAssert(!hasResult(), "FutureState already has a result");
-        _try = std::move(value);
+        _try_value = std::move(value);
 
         auto state = _state.load(std::memory_order_acquire);
         switch (state) {
@@ -268,7 +268,7 @@ private:
                              currentThreadInExecutor())) {
             // execute inplace for better performance
             ContinuationReference guard(this);
-            _continuation(std::move(_try));
+            _continuation(std::move(_try_value));
         } else {
             ContinuationReference guard(this);
             ContinuationReference guardForException(this);
@@ -279,7 +279,7 @@ private:
                         [fsRef = std::move(guard)]() mutable {
                             auto ref = std::move(fsRef);
                             auto fs = ref.getFutureState();
-                            fs->_continuation(std::move(fs->_try));
+                            fs->_continuation(std::move(fs->_try_value));
                         });
                 } else {
                     ScheduleOptions opts;
@@ -290,7 +290,7 @@ private:
                         [fsRef = std::move(guard)]() mutable {
                             auto ref = std::move(fsRef);
                             auto fs = ref.getFutureState();
-                            fs->_continuation(std::move(fs->_try));
+                            fs->_continuation(std::move(fs->_try_value));
                         },
                         _context, opts);
                 }
@@ -300,7 +300,7 @@ private:
                 }
             } catch (std::exception& e) {
                 // reschedule failed, execute inplace
-                _continuation(std::move(_try));
+                _continuation(std::move(_try_value));
             }
         }
     }
@@ -320,7 +320,7 @@ private:
     std::atomic<detail::State> _state;
     std::atomic<uint8_t> _attached;
     std::atomic<uint8_t> _continuationRef;
-    Try<T> _try;
+    Try<T> _try_value;
     union {
         Continuation _continuation;
     };

--- a/async_simple/LocalState.h
+++ b/async_simple/LocalState.h
@@ -44,8 +44,8 @@ private:
 
 public:
     LocalState() : _executor(nullptr) {}
-    LocalState(T&& v) : _try(std::forward<T>(v)), _executor(nullptr) {}
-    LocalState(Try<T>&& t) : _try(std::move(t)), _executor(nullptr) {}
+    LocalState(T&& v) : _try_value(std::forward<T>(v)), _executor(nullptr) {}
+    LocalState(Try<T>&& t) : _try_value(std::move(t)), _executor(nullptr) {}
 
     ~LocalState() {}
 
@@ -53,22 +53,22 @@ public:
     LocalState& operator=(const LocalState&) = delete;
 
     LocalState(LocalState&& other)
-        : _try(std::move(other._try)),
+        : _try_value(std::move(other._try_value)),
           _executor(std::exchange(other._executor, nullptr)) {}
     LocalState& operator=(LocalState&& other) {
         if (this != &other) {
-            std::swap(_try, other._try);
+            std::swap(_try_value, other._try_value);
             std::swap(_executor, other._executor);
         }
         return *this;
     }
 
 public:
-    bool hasResult() const noexcept { return _try.available(); }
+    bool hasResult() const noexcept { return _try_value.available(); }
 
 public:
-    Try<T>& getTry() noexcept { return _try; }
-    const Try<T>& getTry() const noexcept { return _try; }
+    Try<T>& getTry() noexcept { return _try_value; }
+    const Try<T>& getTry() const noexcept { return _try_value; }
 
     void setExecutor(Executor* ex) { _executor = ex; }
 
@@ -83,12 +83,12 @@ public:
 
     template <typename F>
     void setContinuation(F&& f) {
-        assert(_try.available());
-        std::forward<F>(f)(std::move(_try));
+        assert(_try_value.available());
+        std::forward<F>(f)(std::move(_try_value));
     }
 
 private:
-    Try<T> _try;
+    Try<T> _try_value;
     Executor* _executor;
 };
 }  // namespace async_simple

--- a/async_simple/Try.h
+++ b/async_simple/Try.h
@@ -135,9 +135,9 @@ public:
 
 private:
     FL_INLINE void checkHasTry() const {
-        if (_contains == Contains::VALUE) [[likely]] {
-            return;
-        } else if (_contains == Contains::EXCEPTION) {
+        if (_contains == Contains::VALUE)
+            [[likely]] { return; }
+        else if (_contains == Contains::EXCEPTION) {
             std::rethrow_exception(_error);
         } else if (_contains == Contains::NOTHING) {
             throw std::logic_error("Try object is empty");

--- a/async_simple/Try.h
+++ b/async_simple/Try.h
@@ -134,7 +134,7 @@ public:
     }
 
 private:
-    FL_INLINE void checkHasTry() const {
+    AS_INLINE void checkHasTry() const {
         if (_contains == Contains::VALUE)
 #if defined(__clang__) && __clang_major__ < 12
         {

--- a/async_simple/Try.h
+++ b/async_simple/Try.h
@@ -136,11 +136,13 @@ public:
 private:
     FL_INLINE void checkHasTry() const {
         if (_contains == Contains::VALUE)
-        #if defined(__clang__) && __clang_major__ < 12
-            { return; }
-        #else
+#if defined(__clang__) && __clang_major__ < 12
+        {
+            return;
+        }
+#else
             [[likely]] { return; }
-        #endif
+#endif
         else if (_contains == Contains::EXCEPTION) {
             std::rethrow_exception(_error);
         } else if (_contains == Contains::NOTHING) {

--- a/async_simple/Try.h
+++ b/async_simple/Try.h
@@ -136,13 +136,7 @@ public:
 private:
     AS_INLINE void checkHasTry() const {
         if (_contains == Contains::VALUE)
-#if defined(__clang__) && __clang_major__ < 12
-        {
-            return;
-        }
-#else
-            [[likely]] { return; }
-#endif
+            LIKELY { return; }
         else if (_contains == Contains::EXCEPTION) {
             std::rethrow_exception(_error);
         } else if (_contains == Contains::NOTHING) {

--- a/async_simple/Try.h
+++ b/async_simple/Try.h
@@ -136,7 +136,11 @@ public:
 private:
     FL_INLINE void checkHasTry() const {
         if (_contains == Contains::VALUE)
+        #if defined(__clang__) && __clang_major__ < 12
+            { return; }
+        #else
             [[likely]] { return; }
+        #endif
         else if (_contains == Contains::EXCEPTION) {
             std::rethrow_exception(_error);
         } else if (_contains == Contains::NOTHING) {

--- a/async_simple/Try.h
+++ b/async_simple/Try.h
@@ -135,7 +135,7 @@ public:
 
 private:
     FL_INLINE void checkHasTry() const {
-        if (FL_LIKELY(_contains == Contains::VALUE)) {
+        if (_contains == Contains::VALUE) [[likely]] {
             return;
         } else if (_contains == Contains::EXCEPTION) {
             std::rethrow_exception(_error);

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -276,7 +276,7 @@ inline auto collectAllWindowedImpl(size_t maxConcurrency,
             output.push_back(std::move(t));
         }
         if (yield) {
-            co_await Yield();
+            co_await Yield_t();
         }
     }
     co_return std::move(output);

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -177,7 +177,7 @@ struct CollectAllAwaiter {
                 });
             };
             if (Para == true && _input.size() > 1) {
-                if (exec != nullptr) 
+                if (exec != nullptr)
                     [[likely]] {
                         exec->schedule(func);
                         continue;

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -177,10 +177,11 @@ struct CollectAllAwaiter {
                 });
             };
             if (Para == true && _input.size() > 1) {
-                if (exec != nullptr) [[likely]] {
-                    exec->schedule(func);
-                    continue;
-                }
+                if (exec != nullptr) 
+                    [[likely]] {
+                        exec->schedule(func);
+                        continue;
+                    }
             }
             func();
         }

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -178,10 +178,17 @@ struct CollectAllAwaiter {
             };
             if (Para == true && _input.size() > 1) {
                 if (exec != nullptr)
+#if defined(__clang__) && __clang_major__ < 12
+                {
+                    exec->schedule(func);
+                    continue;
+                }
+#else
                     [[likely]] {
                         exec->schedule(func);
                         continue;
                     }
+#endif
             }
             func();
         }

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -177,7 +177,7 @@ struct CollectAllAwaiter {
                 });
             };
             if (Para == true && _input.size() > 1) {
-                if (FL_LIKELY(exec != nullptr)) {
+                if (exec != nullptr) [[likely]] {
                     exec->schedule(func);
                     continue;
                 }

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -178,17 +178,10 @@ struct CollectAllAwaiter {
             };
             if (Para == true && _input.size() > 1) {
                 if (exec != nullptr)
-#if defined(__clang__) && __clang_major__ < 12
-                {
-                    exec->schedule(func);
-                    continue;
-                }
-#else
-                    [[likely]] {
+                    LIKELY {
                         exec->schedule(func);
                         continue;
                     }
-#endif
             }
             func();
         }

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -276,7 +276,7 @@ inline auto collectAllWindowedImpl(size_t maxConcurrency,
             output.push_back(std::move(t));
         }
         if (yield) {
-            co_await Yield_t();
+            co_await Yield();
         }
     }
     co_return std::move(output);

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -43,7 +43,7 @@ class Lazy;
 // ```
 //
 // This would suspend the executing coruotine.
-struct Yield_t {};
+struct Yield {};
 
 namespace detail {
 template <typename LazyType, typename IAlloc, typename OAlloc, bool Para>
@@ -100,7 +100,7 @@ public:
     auto await_transform(CurrentExecutor) {
         return ReadyAwaiter<Executor*>(_executor);
     }
-    auto await_transform(Yield_t) { return YieldAwaiter(_executor); }
+    auto await_transform(Yield) { return YieldAwaiter(_executor); }
 
 public:
     Executor* _executor;

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -143,38 +143,20 @@ public:
 public:
     T& result() & {
         if (_resultType == result_type::exception)
-#if defined(__clang__) && __clang_major__ < 12
-        {
-            std::rethrow_exception(_exception);
-        }
-#else
-            [[unlikely]] { std::rethrow_exception(_exception); }
-#endif
+            UNLIKELY { std::rethrow_exception(_exception); }
         assert(_resultType == result_type::value);
         return _value;
     }
     T&& result() && {
         if (_resultType == result_type::exception)
-#if defined(__clang__) && __clang_major__ < 12
-        {
-            std::rethrow_exception(_exception);
-        }
-#else
-            [[unlikely]] { std::rethrow_exception(_exception); }
-#endif
+            UNLIKELY { std::rethrow_exception(_exception); }
         assert(_resultType == result_type::value);
         return std::move(_value);
     }
 
     Try<T> tryResult() noexcept {
         if (_resultType == result_type::exception)
-#if defined(__clang__) && __clang_major__ < 12
-        {
-            return Try<T>(_exception);
-        }
-#else
-            [[unlikely]] { return Try<T>(_exception); }
-#endif
+            UNLIKELY { return Try<T>(_exception); }
         else {
             assert(_resultType == result_type::value);
             return Try<T>(std::move(_value));
@@ -200,13 +182,7 @@ public:
 
     void result() {
         if (_exception != nullptr)
-#if defined(__clang__) && __clang_major__ < 12
-        {
-            std::rethrow_exception(_exception);
-        }
-#else
-            [[unlikely]] { std::rethrow_exception(_exception); }
-#endif
+            UNLIKELY { std::rethrow_exception(_exception); }
     }
     Try<void> tryResult() noexcept { return Try<void>(_exception); }
 

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -142,14 +142,14 @@ public:
 
 public:
     T& result() & {
-        if (FL_UNLIKELY(_resultType == result_type::exception)) {
+        if (_resultType == result_type::exception) [[unlikely]] {
             std::rethrow_exception(_exception);
         }
         assert(_resultType == result_type::value);
         return _value;
     }
     T&& result() && {
-        if (FL_UNLIKELY(_resultType == result_type::exception)) {
+        if (_resultType == result_type::exception) [[unlikely]] {
             std::rethrow_exception(_exception);
         }
         assert(_resultType == result_type::value);
@@ -157,7 +157,7 @@ public:
     }
 
     Try<T> tryResult() noexcept {
-        if (FL_UNLIKELY(_resultType == result_type::exception)) {
+        if (_resultType == result_type::exception) [[unlikely]] {
             return Try<T>(_exception);
         } else {
             assert(_resultType == result_type::value);
@@ -183,7 +183,7 @@ public:
     }
 
     void result() {
-        if (FL_UNLIKELY(_exception != nullptr)) {
+        if (_exception != nullptr) [[unlikely]] {
             std::rethrow_exception(_exception);
         }
     }

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -43,7 +43,7 @@ class Lazy;
 // ```
 //
 // This would suspend the executing coruotine.
-struct Yield {};
+struct Yield_t {};
 
 namespace detail {
 template <typename LazyType, typename IAlloc, typename OAlloc, bool Para>
@@ -100,7 +100,7 @@ public:
     auto await_transform(CurrentExecutor) {
         return ReadyAwaiter<Executor*>(_executor);
     }
-    auto await_transform(Yield) { return YieldAwaiter(_executor); }
+    auto await_transform(Yield_t) { return YieldAwaiter(_executor); }
 
 public:
     Executor* _executor;
@@ -341,7 +341,7 @@ public:
         using Base = detail::LazyAwaiterBase<T>;
         AwaiterBase(Handle coro) : Base(coro) {}
 
-        __attribute__((__always_inline__)) std::coroutine_handle<>
+        FL_INLINE std::coroutine_handle<>
         await_suspend(std::coroutine_handle<> continuation) noexcept {
             // current coro started, caller becomes my continuation
             Base::_handle.promise()._continuation = continuation;
@@ -358,7 +358,7 @@ public:
 
     struct ValueAwaiter : public AwaiterBase {
         ValueAwaiter(Handle coro) : AwaiterBase(coro) {}
-        __attribute__((__always_inline__)) T await_resume() {
+        FL_INLINE T await_resume() {
             return AwaiterBase::awaitResume();
         }
     };
@@ -472,7 +472,7 @@ private:
     struct ValueAwaiter : public AwaiterBase {
         ValueAwaiter(Handle coro) : AwaiterBase(coro) {}
 
-        __attribute__((__always_inline__)) T await_resume() {
+        FL_INLINE T await_resume() {
             return AwaiterBase::awaitResume();
         }
     };

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -362,7 +362,7 @@ public:
         using Base = detail::LazyAwaiterBase<T>;
         AwaiterBase(Handle coro) : Base(coro) {}
 
-        FL_INLINE std::coroutine_handle<> await_suspend(
+        AS_INLINE std::coroutine_handle<> await_suspend(
             std::coroutine_handle<> continuation) noexcept {
             // current coro started, caller becomes my continuation
             Base::_handle.promise()._continuation = continuation;
@@ -372,14 +372,14 @@ public:
 
     struct TryAwaiter : public AwaiterBase {
         TryAwaiter(Handle coro) : AwaiterBase(coro) {}
-        FL_INLINE Try<T> await_resume() noexcept {
+        AS_INLINE Try<T> await_resume() noexcept {
             return AwaiterBase::awaitResumeTry();
         };
     };
 
     struct ValueAwaiter : public AwaiterBase {
         ValueAwaiter(Handle coro) : AwaiterBase(coro) {}
-        FL_INLINE T await_resume() { return AwaiterBase::awaitResume(); }
+        AS_INLINE T await_resume() { return AwaiterBase::awaitResume(); }
     };
 
     ~Lazy() {
@@ -491,12 +491,12 @@ private:
     struct ValueAwaiter : public AwaiterBase {
         ValueAwaiter(Handle coro) : AwaiterBase(coro) {}
 
-        FL_INLINE T await_resume() { return AwaiterBase::awaitResume(); }
+        AS_INLINE T await_resume() { return AwaiterBase::awaitResume(); }
     };
 
     struct TryAwaiter : public AwaiterBase {
         TryAwaiter(Handle coro) : AwaiterBase(coro) {}
-        FL_INLINE Try<T> await_resume() noexcept {
+        AS_INLINE Try<T> await_resume() noexcept {
             return AwaiterBase::awaitResumeTry();
         };
     };

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -142,24 +142,22 @@ public:
 
 public:
     T& result() & {
-        if (_resultType == result_type::exception) [[unlikely]] {
-            std::rethrow_exception(_exception);
-        }
+        if (_resultType == result_type::exception)
+            [[unlikely]] { std::rethrow_exception(_exception); }
         assert(_resultType == result_type::value);
         return _value;
     }
     T&& result() && {
-        if (_resultType == result_type::exception) [[unlikely]] {
-            std::rethrow_exception(_exception);
-        }
+        if (_resultType == result_type::exception)
+            [[unlikely]] { std::rethrow_exception(_exception); }
         assert(_resultType == result_type::value);
         return std::move(_value);
     }
 
     Try<T> tryResult() noexcept {
-        if (_resultType == result_type::exception) [[unlikely]] {
-            return Try<T>(_exception);
-        } else {
+        if (_resultType == result_type::exception)
+            [[unlikely]] { return Try<T>(_exception); }
+        else {
             assert(_resultType == result_type::value);
             return Try<T>(std::move(_value));
         }
@@ -183,9 +181,8 @@ public:
     }
 
     void result() {
-        if (_exception != nullptr) [[unlikely]] {
-            std::rethrow_exception(_exception);
-        }
+        if (_exception != nullptr)
+            [[unlikely]] { std::rethrow_exception(_exception); }
     }
     Try<void> tryResult() noexcept { return Try<void>(_exception); }
 

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -143,20 +143,38 @@ public:
 public:
     T& result() & {
         if (_resultType == result_type::exception)
+#if defined(__clang__) && __clang_major__ < 12
+        {
+            std::rethrow_exception(_exception);
+        }
+#else
             [[unlikely]] { std::rethrow_exception(_exception); }
+#endif
         assert(_resultType == result_type::value);
         return _value;
     }
     T&& result() && {
         if (_resultType == result_type::exception)
+#if defined(__clang__) && __clang_major__ < 12
+        {
+            std::rethrow_exception(_exception);
+        }
+#else
             [[unlikely]] { std::rethrow_exception(_exception); }
+#endif
         assert(_resultType == result_type::value);
         return std::move(_value);
     }
 
     Try<T> tryResult() noexcept {
         if (_resultType == result_type::exception)
+#if defined(__clang__) && __clang_major__ < 12
+        {
+            return Try<T>(_exception);
+        }
+#else
             [[unlikely]] { return Try<T>(_exception); }
+#endif
         else {
             assert(_resultType == result_type::value);
             return Try<T>(std::move(_value));
@@ -182,7 +200,13 @@ public:
 
     void result() {
         if (_exception != nullptr)
+#if defined(__clang__) && __clang_major__ < 12
+        {
+            std::rethrow_exception(_exception);
+        }
+#else
             [[unlikely]] { std::rethrow_exception(_exception); }
+#endif
     }
     Try<void> tryResult() noexcept { return Try<void>(_exception); }
 

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -231,7 +231,7 @@ TEST_F(LazyTest, testYield) {
     auto test1 = [](std::mutex& m, int& value) -> Lazy<void> {
         m.lock();
         // push task to queue's tail
-        co_await Yield();
+        co_await Yield_t();
         value++;
         co_return;
     };

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -231,7 +231,7 @@ TEST_F(LazyTest, testYield) {
     auto test1 = [](std::mutex& m, int& value) -> Lazy<void> {
         m.lock();
         // push task to queue's tail
-        co_await Yield_t();
+        co_await Yield();
         value++;
         co_return;
     };

--- a/async_simple/executors/SimpleIOExecutor.h
+++ b/async_simple/executors/SimpleIOExecutor.h
@@ -20,7 +20,9 @@
 #ifndef ASYNC_SIMPLE_HAS_NOT_AIO
 #include <libaio.h>
 #endif
+#ifndef _WIN32
 #include <sys/syscall.h> /* For SYS_xxx definitions */
+#endif  // !_WIN32
 #include <thread>
 
 namespace async_simple {

--- a/async_simple/executors/SimpleIOExecutor.h
+++ b/async_simple/executors/SimpleIOExecutor.h
@@ -20,9 +20,7 @@
 #ifndef ASYNC_SIMPLE_HAS_NOT_AIO
 #include <libaio.h>
 #endif
-#ifndef _WIN32
-#include <sys/syscall.h> /* For SYS_xxx definitions */
-#endif  // !_WIN32
+
 #include <thread>
 
 namespace async_simple {

--- a/async_simple/executors/test/CMakeLists.txt
+++ b/async_simple/executors/test/CMakeLists.txt
@@ -1,7 +1,11 @@
 file(GLOB executor_test_src "*.cpp")
 add_executable(async_simple_executor_test ${executor_test_src} ${PROJECT_SOURCE_DIR}/async_simple/test/dotest.cpp)
 
-target_link_libraries(async_simple_executor_test async_simple ${deplibs} ${testdeplibs})
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    target_link_libraries(async_simple_executor_test async_simple ${deplibs} ${testdeplibs})
+else()
+    target_link_libraries(async_simple_executor_test async_simple -pthread ${deplibs} ${testdeplibs})
+endif()
 
 add_test(NAME run_async_simple_executor_test COMMAND async_simple_executor_test)
 

--- a/async_simple/executors/test/CMakeLists.txt
+++ b/async_simple/executors/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 file(GLOB executor_test_src "*.cpp")
 add_executable(async_simple_executor_test ${executor_test_src} ${PROJECT_SOURCE_DIR}/async_simple/test/dotest.cpp)
 
-target_link_libraries(async_simple_executor_test async_simple -pthread ${deplibs} ${testdeplibs})
+target_link_libraries(async_simple_executor_test async_simple ${deplibs} ${testdeplibs})
 
 add_test(NAME run_async_simple_executor_test COMMAND async_simple_executor_test)
 

--- a/async_simple/executors/test/CMakeLists.txt
+++ b/async_simple/executors/test/CMakeLists.txt
@@ -1,11 +1,7 @@
 file(GLOB executor_test_src "*.cpp")
 add_executable(async_simple_executor_test ${executor_test_src} ${PROJECT_SOURCE_DIR}/async_simple/test/dotest.cpp)
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    target_link_libraries(async_simple_executor_test async_simple ${deplibs} ${testdeplibs})
-else()
-    target_link_libraries(async_simple_executor_test async_simple -pthread ${deplibs} ${testdeplibs})
-endif()
+target_link_libraries(async_simple_executor_test async_simple ${deplibs} ${testdeplibs})
 
 add_test(NAME run_async_simple_executor_test COMMAND async_simple_executor_test)
 

--- a/async_simple/experimental/coroutine.h
+++ b/async_simple/experimental/coroutine.h
@@ -55,7 +55,7 @@ template <class P> struct hash<coroutine_handle<P>>;
 // we could only use self-provided coroutine header.
 // Note: the <coroutine> header in libc++ is available for both clang and gcc.
 // And the outdated <experimental/coroutine> is available for clang only.
-#if (__cplusplus <= 201703L) || (defined(__clang__) && defined(__GLIBCXX__))
+#if (__cplusplus <= 201703L && !defined(_MSC_VER)) || (defined(__clang__) && defined(__GLIBCXX__))
 #define USE_SELF_DEFINED_COROUTINE
 #endif
 
@@ -391,6 +391,7 @@ using std::experimental::suspend_never;
 
 #endif /* HAS_NON_EXPERIMENTAL_COROUTINE */
 
+#if !defined(_MSC_VER)
 namespace std {
 
 template <class _Tp>
@@ -402,6 +403,7 @@ struct hash<coroutine_handle<_Tp> > {
     }
 };
 }  // namespace std
+#endif
 
 namespace async_simple {
 namespace coro {

--- a/async_simple/experimental/coroutine.h
+++ b/async_simple/experimental/coroutine.h
@@ -54,7 +54,8 @@ template <class P> struct hash<coroutine_handle<P>>;
 // clang couldn't compile <coroutine> in libstdc++. In this case,
 // we could only use self-provided coroutine header.
 // Note: the <coroutine> header in libc++ is available for both clang and gcc.
-// And the outdated <experimental/coroutine> is available for clang only.
+// And the outdated <experimental/coroutine> is available for clang only(need to
+// exclude msvc).
 #if (__cplusplus <= 201703L && !defined(_MSC_VER)) || \
     (defined(__clang__) && defined(__GLIBCXX__))
 #define USE_SELF_DEFINED_COROUTINE

--- a/async_simple/test/FutureTest.cpp
+++ b/async_simple/test/FutureTest.cpp
@@ -457,7 +457,7 @@ TEST_F(FutureTest, testViaAfterWait) {
     auto future = promise.getFuture();
 
     auto t = std::thread([p = std::move(promise)]() mutable {
-        sleep(1);
+        std::this_thread::sleep_for(1s);
         p.setValue(100);
     });
 

--- a/async_simple/uthread/Async.h
+++ b/async_simple/uthread/Async.h
@@ -59,7 +59,13 @@ template <class T, class F,
                                   T>::type* = nullptr>
 inline void async(F&& f, Executor* ex) {
     if (!ex)
+#if defined(__clang__) && __clang_major__ < 12
+    {
+        return;
+    }
+#else
         [[unlikely]] { return; }
+#endif
     ex->schedule([f = std::move(f), ex]() {
         Uthread uth(Attribute{ex}, std::move(f));
         uth.detach();
@@ -72,7 +78,13 @@ template <class T, class F, class C,
                                   T>::type* = nullptr>
 inline void async(F&& f, C&& c, Executor* ex) {
     if (!ex)
+#if defined(__clang__) && __clang_major__ < 12
+    {
+        return;
+    }
+#else
         [[unlikely]] { return; }
+#endif
     ex->schedule([f = std::move(f), c = std::move(c), ex]() {
         Uthread uth(Attribute{ex}, std::move(f));
         uth.join(std::move(c));

--- a/async_simple/uthread/Async.h
+++ b/async_simple/uthread/Async.h
@@ -58,7 +58,7 @@ template <class T, class F,
           typename std::enable_if<std::is_same<T, Launch::Schedule>::value,
                                   T>::type* = nullptr>
 inline void async(F&& f, Executor* ex) {
-    if (FL_UNLIKELY(!ex)) {
+    if (!ex) [[unlikely]] {
         return;
     }
     ex->schedule([f = std::move(f), ex]() {
@@ -72,7 +72,7 @@ template <class T, class F, class C,
           typename std::enable_if<std::is_same<T, Launch::Schedule>::value,
                                   T>::type* = nullptr>
 inline void async(F&& f, C&& c, Executor* ex) {
-    if (FL_UNLIKELY(!ex)) {
+    if (!ex) [[unlikely]] {
         return;
     }
     ex->schedule([f = std::move(f), c = std::move(c), ex]() {

--- a/async_simple/uthread/Async.h
+++ b/async_simple/uthread/Async.h
@@ -59,13 +59,7 @@ template <class T, class F,
                                   T>::type* = nullptr>
 inline void async(F&& f, Executor* ex) {
     if (!ex)
-#if defined(__clang__) && __clang_major__ < 12
-    {
-        return;
-    }
-#else
-        [[unlikely]] { return; }
-#endif
+        UNLIKELY { return; }
     ex->schedule([f = std::move(f), ex]() {
         Uthread uth(Attribute{ex}, std::move(f));
         uth.detach();
@@ -78,13 +72,7 @@ template <class T, class F, class C,
                                   T>::type* = nullptr>
 inline void async(F&& f, C&& c, Executor* ex) {
     if (!ex)
-#if defined(__clang__) && __clang_major__ < 12
-    {
-        return;
-    }
-#else
-        [[unlikely]] { return; }
-#endif
+        UNLIKELY { return; }
     ex->schedule([f = std::move(f), c = std::move(c), ex]() {
         Uthread uth(Attribute{ex}, std::move(f));
         uth.join(std::move(c));

--- a/async_simple/uthread/Async.h
+++ b/async_simple/uthread/Async.h
@@ -58,7 +58,7 @@ template <class T, class F,
           typename std::enable_if<std::is_same<T, Launch::Schedule>::value,
                                   T>::type* = nullptr>
 inline void async(F&& f, Executor* ex) {
-    if (!ex) 
+    if (!ex)
         [[unlikely]] { return; }
     ex->schedule([f = std::move(f), ex]() {
         Uthread uth(Attribute{ex}, std::move(f));
@@ -71,7 +71,7 @@ template <class T, class F, class C,
           typename std::enable_if<std::is_same<T, Launch::Schedule>::value,
                                   T>::type* = nullptr>
 inline void async(F&& f, C&& c, Executor* ex) {
-    if (!ex) 
+    if (!ex)
         [[unlikely]] { return; }
     ex->schedule([f = std::move(f), c = std::move(c), ex]() {
         Uthread uth(Attribute{ex}, std::move(f));

--- a/async_simple/uthread/Async.h
+++ b/async_simple/uthread/Async.h
@@ -58,9 +58,8 @@ template <class T, class F,
           typename std::enable_if<std::is_same<T, Launch::Schedule>::value,
                                   T>::type* = nullptr>
 inline void async(F&& f, Executor* ex) {
-    if (!ex) [[unlikely]] {
-        return;
-    }
+    if (!ex) 
+        [[unlikely]] { return; }
     ex->schedule([f = std::move(f), ex]() {
         Uthread uth(Attribute{ex}, std::move(f));
         uth.detach();
@@ -72,9 +71,8 @@ template <class T, class F, class C,
           typename std::enable_if<std::is_same<T, Launch::Schedule>::value,
                                   T>::type* = nullptr>
 inline void async(F&& f, C&& c, Executor* ex) {
-    if (!ex) [[unlikely]] {
-        return;
-    }
+    if (!ex) 
+        [[unlikely]] { return; }
     ex->schedule([f = std::move(f), c = std::move(c), ex]() {
         Uthread uth(Attribute{ex}, std::move(f));
         uth.join(std::move(c));

--- a/async_simple/uthread/internal/thread.cc
+++ b/async_simple/uthread/internal/thread.cc
@@ -54,7 +54,7 @@ size_t get_base_stack_size() {
 
 inline void jmp_buf_link::switch_in() {
     link = std::exchange(g_current_context, this);
-    if (FL_UNLIKELY(!link)) {
+    if (!link) [[unlikely]] {
         link = &g_unthreaded_context;
     }
     fcontext = _fl_jump_fcontext(fcontext, thread).fctx;

--- a/async_simple/uthread/internal/thread.cc
+++ b/async_simple/uthread/internal/thread.cc
@@ -55,13 +55,7 @@ size_t get_base_stack_size() {
 inline void jmp_buf_link::switch_in() {
     link = std::exchange(g_current_context, this);
     if (!link)
-#if defined(__clang__) && __clang_major__ < 12
-    {
-        link = &g_unthreaded_context;
-    }
-#else
-        [[unlikely]] { link = &g_unthreaded_context; }
-#endif
+        UNLIKELY { link = &g_unthreaded_context; }
     fcontext = _fl_jump_fcontext(fcontext, thread).fctx;
 }
 

--- a/async_simple/uthread/internal/thread.cc
+++ b/async_simple/uthread/internal/thread.cc
@@ -55,7 +55,11 @@ size_t get_base_stack_size() {
 inline void jmp_buf_link::switch_in() {
     link = std::exchange(g_current_context, this);
     if (!link)
+    #if defined(__clang__) && __clang_major__ < 12
+        { link = &g_unthreaded_context; }
+    #else
         [[unlikely]] { link = &g_unthreaded_context; }
+    #endif
     fcontext = _fl_jump_fcontext(fcontext, thread).fctx;
 }
 

--- a/async_simple/uthread/internal/thread.cc
+++ b/async_simple/uthread/internal/thread.cc
@@ -54,9 +54,8 @@ size_t get_base_stack_size() {
 
 inline void jmp_buf_link::switch_in() {
     link = std::exchange(g_current_context, this);
-    if (!link) [[unlikely]] {
-        link = &g_unthreaded_context;
-    }
+    if (!link) 
+        [[unlikely]] { link = &g_unthreaded_context; }
     fcontext = _fl_jump_fcontext(fcontext, thread).fctx;
 }
 

--- a/async_simple/uthread/internal/thread.cc
+++ b/async_simple/uthread/internal/thread.cc
@@ -54,7 +54,7 @@ size_t get_base_stack_size() {
 
 inline void jmp_buf_link::switch_in() {
     link = std::exchange(g_current_context, this);
-    if (!link) 
+    if (!link)
         [[unlikely]] { link = &g_unthreaded_context; }
     fcontext = _fl_jump_fcontext(fcontext, thread).fctx;
 }

--- a/async_simple/uthread/internal/thread.cc
+++ b/async_simple/uthread/internal/thread.cc
@@ -55,11 +55,13 @@ size_t get_base_stack_size() {
 inline void jmp_buf_link::switch_in() {
     link = std::exchange(g_current_context, this);
     if (!link)
-    #if defined(__clang__) && __clang_major__ < 12
-        { link = &g_unthreaded_context; }
-    #else
+#if defined(__clang__) && __clang_major__ < 12
+    {
+        link = &g_unthreaded_context;
+    }
+#else
         [[unlikely]] { link = &g_unthreaded_context; }
-    #endif
+#endif
     fcontext = _fl_jump_fcontext(fcontext, thread).fctx;
 }
 

--- a/demo_example/CMakeLists.txt
+++ b/demo_example/CMakeLists.txt
@@ -19,10 +19,10 @@ add_executable(async_echo_client async_echo_client.cpp)
 target_link_libraries(async_echo_client async_simple)
 
 add_executable(block_echo_server block_echo_server.cpp)
-target_link_libraries(block_echo_server pthread)
+target_link_libraries(block_echo_server ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(block_echo_client block_echo_client.cpp)
-target_link_libraries(block_echo_client pthread)
+target_link_libraries(block_echo_client ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(http_server http/coroutine_http/http_server.cpp)
 target_link_libraries(http_server async_simple)
@@ -46,7 +46,7 @@ endif()
 
 add_executable(smtp_client smtp/smtp_client.cpp)
 if (ENABLE_SSL)
-    target_link_libraries(smtp_client pthread OpenSSL::SSL)
+    target_link_libraries(smtp_client ${CMAKE_THREAD_LIBS_INIT} OpenSSL::SSL)
 else()
-    target_link_libraries(smtp_client pthread)
+    target_link_libraries(smtp_client ${CMAKE_THREAD_LIBS_INIT})
 endif()

--- a/demo_example/io_context_pool.hpp
+++ b/demo_example/io_context_pool.hpp
@@ -18,7 +18,7 @@
 #include <memory>
 #include <thread>
 #include <vector>
-#include "asio.hpp"
+#include "asio_util.hpp"
 
 class io_context_pool {
 public:

--- a/demo_example/smtp/smtp_client.cpp
+++ b/demo_example/smtp/smtp_client.cpp
@@ -342,7 +342,7 @@ private:
 private:
     std::string get_separator() {
 #ifdef _WIN32
-        return '\\';
+        return "\\";
 #endif
         return "/";
     }


### PR DESCRIPTION
## Why

Closes #72 

## What is changing

name conflicts to windows:
- _try --> _try_value
- Yield() --> Yield_t()

not exist functions on windows:
- ```__builtin_expect --> #define __builtin_expect(EXP, C) (EXP)```
- ```__attribute__((__always_inline__)) --> #define FL_INLINE inline```

change some compile options for windows:
- pthread
- async_simple static lib
- some c++ compile options

