### PR TITLE
Support dbg scripts and document for debugging

### DIFF
--- a/async_simple/coro/CoAwait.h
+++ b/async_simple/coro/CoAwait.h
@@ -73,8 +73,10 @@ public:
             Executor::Context _ctx;
         };
 
-        Executor* _ex;
+        /// IMPORTANT: _continuation should be the first member due to the
+        /// requirement of dbg script.
         std::coroutine_handle<> _continuation;
+        Executor* _ex;
         Executor::Context _ctx;
     };
 

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -102,9 +102,10 @@ public:
     }
     auto await_transform(Yield) { return YieldAwaiter(_executor); }
 
-public:
-    Executor* _executor;
+    /// IMPORTANT: _continuation should be the first member due to the
+    /// requirement of dbg script.
     std::coroutine_handle<> _continuation;
+    Executor* _executor;
 };
 
 template <typename T>

--- a/async_simple/coro/Util.h
+++ b/async_simple/coro/Util.h
@@ -53,6 +53,10 @@ struct DetachedCoroutine {
         DetachedCoroutine get_return_object() noexcept {
             return DetachedCoroutine();
         }
+
+        // Hint to gdb script for that there is no continuation for
+        // DetachedCoroutine.
+        std::coroutine_handle<> _continuation = nullptr;
     };
 };
 

--- a/dbg/LazyStack.py
+++ b/dbg/LazyStack.py
@@ -1,0 +1,186 @@
+"""
+    Copyright (c) 2022, Alibaba Group Holding Limited;
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+        http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+import gdb
+from gdb.FrameDecorator import FrameDecorator
+import traceback
+
+"""
+IMPORTANT: This scripts assumes that all the promise_type have the 
+           continuation field as the first data member.
+"""
+
+class SymValueWrapper():
+    def __init__(self, symbol, value):
+        self.sym = symbol
+        self.val = value
+
+    def value(self):
+        return self.val
+
+    def symbol(self):
+        return self.sym
+
+    def __str__(self):
+        return str(self.sym) + " = " + str(self.val)
+
+class LazyGetType(object):
+    def __init__(self, cls):
+        self.cls = cls
+    def __getattr__(self, name):
+        if name.endswith('_size'):
+            value = getattr(self, name[:-len('_size')]).sizeof
+        elif name.endswith('_pointer'):
+            value = getattr(self, name[:-len('_pointer')]).pointer()
+        else:
+            value = gdb.lookup_type(self.cls.type_map[name])
+        setattr(self, name, value)
+        return value
+
+@LazyGetType
+class types(object):
+    type_map = {'long': 'long',
+                'promise_base': 'async_simple::coro::detail::LazyPromiseBase',
+                'continuation': 'std::coroutine_handle<void>'
+               }
+
+class CoroutineFrame(object):
+    def __init__(self, task_addr):
+        self.promise_base_addr = task_addr + types.long_pointer_size * 2
+        # In async_simple, the continuation address should be equal to promise_address
+        self.continuation_addr = self.promise_base_addr
+
+    def next_task_addr(self):
+        return dereference(self.continuation_addr)
+
+    def __getattr__(self, name):
+        if name.endswith("_pointer"):
+            name = name[:-len("_pointer")]
+            return cast_addr2long_pointer(object.__getattribute__(self, name))
+        print "Search: ", name
+        return object.__getattribute__(self, name)
+
+def cast_addr2long_pointer(addr):
+    return gdb.Value(addr).cast(types.long_pointer)
+
+def dereference(addr):
+    return long(cast_addr2long_pointer(addr).dereference())
+
+class StacklessCoroutineFrame(CoroutineFrame):
+    def __init__(self, task_addr):
+        super(StacklessCoroutineFrame, self).__init__(task_addr)
+
+        self.resume_addr_size = types.long_pointer_size
+        self.destroy_addr_size = types.long_pointer_size
+
+        self.promise_type_addr = self.promise_base_addr
+        self.destroy_addr = self.promise_type_addr - self.destroy_addr_size
+        self.resume_addr = self.destroy_addr - self.resume_addr_size
+        self.frame_addr = self.resume_addr
+        self.other_fields = self.continuation_addr + types.continuation_size
+
+class StacklessCoroutineFrameDecorator(FrameDecorator):
+    def __init__(self, frame, coro_frame):
+        super(StacklessCoroutineFrameDecorator, self).__init__(frame)
+        self.coro_frame = coro_frame
+
+        self.resume_func = dereference(self.coro_frame.resume_addr)
+        self.resume_func_block = gdb.block_for_pc(self.resume_func)
+        if self.resume_func_block == None:
+            raise 'Not stackless coroutine.'
+        self.line_info = gdb.find_pc_line(self.resume_func)
+
+    def address(self):
+        return self.resume_func
+
+    def filename(self):
+        return self.line_info.symtab.filename
+
+    def frame_args(self):
+        return [SymValueWrapper("frame_addr", self.coro_frame.frame_addr_pointer),
+                SymValueWrapper("promise_addr", self.coro_frame.promise_base_addr_pointer),
+                SymValueWrapper("continuation_addr", self.coro_frame.continuation_addr_pointer),
+                SymValueWrapper("others_addr", self.coro_frame.other_fields_pointer)
+                ]
+
+    def function(self):
+        return self.resume_func_block.function.print_name
+
+    def line(self):
+        return self.line_info.line
+
+class StripDecorator(FrameDecorator):
+    def __init__(self, frame):
+        super(StripDecorator, self).__init__(frame)
+        self.frame = frame
+        f = frame.function()
+        self.function_name = f
+        self.elided_frames = None
+        if not isinstance(f, str):
+            self.template_arguments = []
+            return
+    
+    def __str__(self, shift = 2):
+        addr = "" if self.address() == None else '%#x' % self.address() + " in "
+        location = "" if self.filename() == None else " at " + self.filename() + ":" + str(self.line())
+        return addr + self.function() + " " + str([str(args) for args in self.frame_args()]) + location
+
+class CoroutineFilter:
+    def create_coroutine_frames(self, frame, task_addr, append_first = False):
+        if append_first:
+            next_task_addr = task_addr
+        else:
+            coro_frame = CoroutineFrame(task_addr)
+            next_task_addr = coro_frame.next_task_addr()
+        frames = []
+        while next_task_addr != 0:
+            try:
+                coro_frame = StacklessCoroutineFrame(next_task_addr)
+                frames.append(StacklessCoroutineFrameDecorator(frame, coro_frame))
+            except Exception as e:
+                traceback.print_exc()
+                return frames
+            next_task_addr = coro_frame.next_task_addr()
+        return frames
+
+class LazyStack(gdb.Command):
+    def __init__(self):
+        super(LazyStack, self).__init__("lazy-bt", gdb.COMMAND_USER)
+
+    def invoke(self, arg, from_tty):
+        coroutine_filter = CoroutineFilter()
+        argv = gdb.string_to_argv(arg)
+        if len(argv) == 0:
+            try:
+                task = gdb.parse_and_eval('__coro_frame')
+                task = int(str(task.address), 16)
+            except Exception:
+                print ("Can't find __coro_frame in current context.\n" +
+                       "Please use `lazy-bt` in stackless coroutine context.")
+                return
+        elif len(argv) != 1:
+            print("usage: lazy-bt <pointer to task>")
+            return
+        else:
+            task = int(argv[0], 16)
+        frames = coroutine_filter.create_coroutine_frames(None, task, True)
+        i = 0
+        for f in frames:
+            print '#'+ str(i), str(StripDecorator(f))
+            i += 1
+        return
+
+LazyStack()

--- a/docs/docs.cn/调试 Lazy.md
+++ b/docs/docs.cn/调试 Lazy.md
@@ -1,0 +1,26 @@
+在 C++20 协程的设计中，协程帧对于程序员来说应该是无感知的。这种设计使得编译器有更多空间对协程帧进行优化。然而程序员在调试时常常需要查看程序的内存布局。由于协程帧不是标准的一部分，且各个编译器的实现有差异。此文档中所描述的方法只对 Clang (>= 11.0.1) 中生效。
+
+# Print Coroutine Frame
+
+我们可以在 gdb/lldb 中通过以下命令打印协程帧的内存：
+```
+p __coro_frame
+```
+
+# Print Promise
+
+我们可以在 gdb/lldb 中通过以下命令打印当前协程 Promise 对象的内容。
+```
+p __promise
+```
+
+# Print asynchronous call stack
+
+此功能由 dbg/LazyStack.py 脚本实现，只对 async_simple 有效。
+
+我们可以通过以下命令打印出无栈协程的异步调用栈。
+```
+source /path/to/async_simple/dbg/LazyStack.py
+lazy-bt # if you are in stackless coroutine context
+lazy-bt 0xffffffff # 0xffffffff should be the address of corresponding frame
+```

--- a/docs/docs.en/DebuggingLazy.md
+++ b/docs/docs.en/DebuggingLazy.md
@@ -1,0 +1,30 @@
+The C++20 coroutine frame is meant to be transparent for users by design. In the design of C++20 coroutine,
+the users shouldn't care about corouitne frame. The users should only know that the compiler would maintain everything well.
+The reason for the decision is that the opaqueness for the usesrs leaves optimization spaces for compilers. Due to coroutine frame is transparent for users, compiler is free to do optimizations, like reducing the size of coroutine frame.
+
+However, the users could believe compiler. But it is necessary for users to know the value in coroutine frame to helping debugging their programs. Due to the implementation of coroutine frame in compilers is not standardized. The method described in the document is not guaranteed to be generalized.
+
+The document is based on Clang (>= 11.0.1) only now.
+
+# Print Coroutine Frame
+
+To print the layout of a coroutine frame, we could use following command to print the layout of the frame for the current coroutine in gdb/lldb:
+```
+p __coro_frame
+```
+
+# Print Promise
+
+Promise is important data structure for each kind of coroutine. We could use following command to print the Promise object for the current frame in gdb/lld:
+```
+p __promise
+```
+
+# Print asynchronous call stack
+
+This section is specified to async_simple. To get the backtrace for stackless coroutine in gdb, we could run:
+```
+source /path/to/async_simple/dbg/LazyStack.py
+lazy-bt # if you are in stackless coroutine context
+lazy-bt 0xffffffff # 0xffffffff should be the address of corresponding frame
+```


### PR DESCRIPTION
- Offering gdb scripts to print the asynchronous stack trace for stackless coroutine components in async_simple.
- Add document for debugging stalkless coroutine and how to use the new script.