### PR TITLE
Remove unused captures

### DIFF
--- a/async_simple/uthread/test/UthreadTest.cpp
+++ b/async_simple/uthread/test/UthreadTest.cpp
@@ -61,9 +61,7 @@ public:
             auto ctx = ex->checkout();
             std::thread([handle, e = ex, ctx]() mutable {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                Executor::Func f = [handle, ctx = std::move(ctx)]() mutable {
-                    handle.resume();
-                };
+                Executor::Func f = [handle]() mutable { handle.resume(); };
                 e->checkin(std::move(f), ctx);
             }).detach();
         }
@@ -319,9 +317,7 @@ struct Awaiter {
         auto ctx = ex->checkout();
         std::thread([handle, e = ex, ctx]() mutable {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            Executor::Func f = [handle, ctx = std::move(ctx)]() mutable {
-                handle.resume();
-            };
+            Executor::Func f = [handle]() mutable { handle.resume(); };
             e->checkin(std::move(f), ctx);
         }).detach();
     }


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## Why

Newest clang would check if the captured variables are used or not. So it would block async_simple to be compiled by newest clang.



