### PR TITLE
Remove unused using in unittest.h

### DIFF
--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -1162,7 +1162,7 @@ TEST_F(LazyTest, testDestroyOrder) {
         co_return v;
     };
     syncAwait(test().via(&_executor));
-    EXPECT_THAT(A::destroyOrder, ElementsAre(1, 7, 1, 0, 999));
+    EXPECT_THAT(A::destroyOrder, testing::ElementsAre(1, 7, 1, 0, 999));
 }
 
 namespace detail {

--- a/async_simple/test/unittest.h
+++ b/async_simple/test/unittest.h
@@ -22,17 +22,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using testing::_;
-using testing::DoAll;
-using testing::ElementsAre;
-using testing::InSequence;
-using testing::Invoke;
-using testing::Return;
-using testing::ReturnRef;
-using testing::SetArgReferee;
-using testing::Throw;
-using testing::UnorderedElementsAre;
-
 class FUTURE_TESTBASE : public testing::Test {
 public:
     virtual void caseSetUp() = 0;


### PR DESCRIPTION
The using statement in unittest.h is meaningless and it is possible to
make async_simple incompatible for user whose version of goolgetest is
not high enough.
