### PR TITLE
Add executor argument to syncAwait

### DIFF
--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -383,6 +383,8 @@ public:
         return RescheduleLazy<T>(std::exchange(_coro, nullptr));
     }
 
+    Executor* getExecutor() { return _coro.promise()._executor; }
+
     // Bind an executor only. Don't re-schedule.
     //
     // Users shouldn't use `setEx` directly. `setEx` is designed
@@ -423,9 +425,6 @@ public:
 private:
     Handle _coro;
     friend class RescheduleLazy<T>;
-
-    template <typename C>
-    friend typename std::decay_t<C>::ValueType syncAwait(C&&);
 
     template <typename LazyType, typename IAlloc, typename OAlloc, bool Para>
     friend struct detail::CollectAllAwaiter;
@@ -487,6 +486,8 @@ public:
     RescheduleLazy(RescheduleLazy&& other)
         : _coro(std::exchange(other._coro, nullptr)) {}
 
+    Executor* getExecutor() { return _coro.promise()._executor; }
+
     auto operator co_await() noexcept {
         return ValueAwaiter(std::exchange(_coro, nullptr));
     }
@@ -514,9 +515,6 @@ public:
 private:
     Handle _coro;
     friend class Lazy<T>;
-
-    template <typename C>
-    friend typename std::decay_t<C>::ValueType syncAwait(C&&);
 
     template <typename LazyType, typename IAlloc, typename OAlloc, bool Para>
     friend struct detail::CollectAllAwaiter;

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -201,6 +201,17 @@ TEST_F(LazyTest, testSimpleAsync) {
     ASSERT_EQ(101, syncAwait(test().via(&_executor)));
 }
 
+TEST_F(LazyTest, testSimpleAsync2) {
+    auto test = [this]() -> Lazy<int> {
+        CHECK_EXECUTOR(&_executor);
+        auto ret = co_await plusOne();
+        CHECK_EXECUTOR(&_executor);
+        co_return ret;
+    };
+    triggerValue(100);
+    ASSERT_EQ(101, syncAwait(test(), &_executor));
+}
+
 TEST_F(LazyTest, testVia) {
     auto test = [this]() -> Lazy<int> {
         auto tid = std::this_thread::get_id();

--- a/demo_example/ReadFiles.cpp
+++ b/demo_example/ReadFiles.cpp
@@ -177,8 +177,7 @@ int main() {
     f.wait();
 
     std::cout << "Calculating char counts asynchronously by coroutine.\n";
-    auto Task = CountCharInFilesCoro(Files, 'x').via(&executor);
-    auto ResCoro = syncAwait(std::move(Task));
+    auto ResCoro = syncAwait(CountCharInFilesCoro(Files, 'x'), &executor);
     std::cout << "Files contain " << ResCoro << " 'x' chars.\n";
 
     return 0;


### PR DESCRIPTION
It would be more straight forward to add an executor argument to
syncAwait.

Closing #101 