### PR TITLE
Decrease the scale of LazyPerf test under Debug mode

### DIFF
--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -1197,8 +1197,8 @@ TEST_F(LazyTest, testLazyPerf) {
     // The code compiled by GCC with Debug would fail
     // if test_loop is 5000.
 #ifndef NDEBUG
-    auto test_loop = 500;
-    auto expected_sum = 232500;
+    auto test_loop = 50;
+    auto expected_sum = 23250;
 #else
     auto test_loop = 5000;
     auto expected_sum = 2325000;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

The symmetric transfer is not part of C++ standard and it might be able to do at O0. So we chose to decrease the scale of LazyPerf further more.

## What is changing

## Example


