### PR TITLE
Detect the presence of [[likely]] properly

### DIFF
--- a/async_simple/Common.h
+++ b/async_simple/Common.h
@@ -18,12 +18,12 @@
 
 #include <stdexcept>
 
-#if defined(__clang__) && __clang_major__ < 12
-#define LIKELY
-#define UNLIKELY
-#else
+#if __has_cpp_attribute(likely) && __has_cpp_attribute(unlikely)
 #define LIKELY [[likely]]
 #define UNLIKELY [[unlikely]]
+#else
+#define LIKELY
+#define UNLIKELY
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

The previous method to  detect the presence of [[likely]] doesn't think of GCC.  Try to detect it properly.

## What is changing

## Example


