### PR TITLE
allow temporary object as param in variadic collectAll

### DIFF
--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -350,8 +350,10 @@ inline auto collectAllPara(std::vector<LazyType<T>, IAlloc>&& input,
 // LazyType tasks in one thread,and producing a tuple of Try values containing
 // each of the results.
 template <template <typename> typename LazyType, typename... Ts>
-inline auto collectAll(LazyType<Ts>&&... inputs)
-    -> Lazy<std::tuple<Try<Ts>...>> {
+// The temporary object's life-time which binding to reference(inputs) won't
+// be extended to next time of coroutine resume. Just Copy inputs to avoid
+// crash.
+inline auto collectAll(LazyType<Ts>... inputs) -> Lazy<std::tuple<Try<Ts>...>> {
     if constexpr (0 == sizeof...(Ts)) {
         co_return std::tuple<>{};
     } else {
@@ -364,7 +366,7 @@ inline auto collectAll(LazyType<Ts>&&... inputs)
 // used to concurrently co_await on some different kinds of LazyType tasks in
 // executor,and producing a tuple of Try values containing each of the results.
 template <template <typename> typename LazyType, typename... Ts>
-inline auto collectAllPara(LazyType<Ts>&&... inputs)
+inline auto collectAllPara(LazyType<Ts>... inputs)
     -> Lazy<std::tuple<Try<Ts>...>> {
     if constexpr (0 == sizeof...(Ts)) {
         co_return std::tuple<>{};


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Almostly Fix #127

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

In the variadic overload of collectAll, we can just copy the lazy<T> instead of reference. The copy is trivally.

However, it's expensive to copy in the vector<lazy<T>> overloaded. Maybe we can use span<lazy<T>> to instead, but it will cause interface change.

Luckily, only the empty temporary vector will cause crash(the non empty temporary vector will cause a compiler error in initialization)

## Example

see test in LazyTest.cpp