### PR TITLE
fix unused parameter warning

### DIFF
--- a/async_simple/Executor.h
+++ b/async_simple/Executor.h
@@ -99,7 +99,8 @@ public:
     // same "Context" as before.
     virtual size_t currentContextId() const { return 0; };
     virtual Context checkout() { return NULLCTX; }
-    virtual bool checkin(Func func, Context ctx, ScheduleOptions opts) {
+    virtual bool checkin(Func func, [[maybe_unused]] Context ctx,
+                         [[maybe_unused]] ScheduleOptions opts) {
         return schedule(std::move(func));
     }
     virtual bool checkin(Func func, Context ctx) {

--- a/async_simple/coro/ViaCoroutine.h
+++ b/async_simple/coro/ViaCoroutine.h
@@ -94,7 +94,7 @@ public:
         : _coro(std::exchange(other._coro, nullptr)) {}
 
 public:
-    static ViaCoroutine create(Executor* ex) { co_return; }
+    static ViaCoroutine create([[maybe_unused]] Executor* ex) { co_return; }
 
 public:
     void checkin() {


### PR DESCRIPTION

```
In file included from /home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/coro/ViaCoroutine.h:29,
                 from /home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/coro/Lazy.h:22,
                 from /home/fantasy/wormhole/include/utils.h:9,
                 from /home/fantasy/wormhole/src/wormhole_client.cpp:11:
/home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/Executor.h: In member function ‘virtual bool async_simple::Executor::checkin(async_simple::Executor::Func, async_simple::Executor::Context, async_simple::ScheduleOptions)’:
/home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/Executor.h:102:45: warning: unused parameter ‘ctx’ [-Wunused-parameter]
  102 |     virtual bool checkin(Func func, Context ctx, ScheduleOptions opts) {
      |                                     ~~~~~~~~^~~
/home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/Executor.h:102:66: warning: unused parameter ‘opts’ [-Wunused-parameter]
  102 |     virtual bool checkin(Func func, Context ctx, ScheduleOptions opts) {
      |                                                  ~~~~~~~~~~~~~~~~^~~~
In file included from /home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/coro/Lazy.h:22,
                 from /home/fantasy/wormhole/include/utils.h:9,
                 from /home/fantasy/wormhole/src/wormhole_client.cpp:11:
/home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/coro/ViaCoroutine.h: In static member function ‘static async_simple::coro::detail::ViaCoroutine async_simple::coro::detail::ViaCoroutine::create(async_simple::Executor*)’:
/home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/coro/ViaCoroutine.h:97:42: warning: unused parameter ‘ex’ [-Wunused-parameter]
   97 |     static ViaCoroutine create(Executor* ex) { co_return; }
      |                                ~~~~~~~~~~^~
In file included from /home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/coro/ViaCoroutine.h:29,
                 from /home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/coro/Lazy.h:22,
                 from /home/fantasy/wormhole/include/utils.h:9,
                 from /home/fantasy/wormhole/src/wormhole_server.cpp:13:
/home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/Executor.h: In member function ‘virtual bool async_simple::Executor::checkin(async_simple::Executor::Func, async_simple::Executor::Context, async_simple::ScheduleOptions)’:
/home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/Executor.h:102:45: warning: unused parameter ‘ctx’ [-Wunused-parameter]
  102 |     virtual bool checkin(Func func, Context ctx, ScheduleOptions opts) {
      |                                     ~~~~~~~~^~~
/home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/Executor.h:102:66: warning: unused parameter ‘opts’ [-Wunused-parameter]
  102 |     virtual bool checkin(Func func, Context ctx, ScheduleOptions opts) {
      |                                                  ~~~~~~~~~~~~~~~~^~~~
In file included from /home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/coro/Lazy.h:22,
                 from /home/fantasy/wormhole/include/utils.h:9,
                 from /home/fantasy/wormhole/src/wormhole_server.cpp:13:
/home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/coro/ViaCoroutine.h: In static member function ‘static async_simple::coro::detail::ViaCoroutine async_simple::coro::detail::ViaCoroutine::create(async_simple::Executor*)’:
/home/fantasy/.xmake/packages/a/async_simple/main/4e0143c97b65425b855ad5fd03038b6a/include/async_simple/coro/ViaCoroutine.h:97:42: warning: unused parameter ‘ex’ [-Wunused-parameter]
```
