### PR TITLE
rename LIKELY/UNLIKELY to avoid definition conflict (#135)

### DIFF
--- a/async_simple/Common.h
+++ b/async_simple/Common.h
@@ -19,11 +19,11 @@
 #include <stdexcept>
 
 #if __has_cpp_attribute(likely) && __has_cpp_attribute(unlikely)
-#define LIKELY [[likely]]
-#define UNLIKELY [[unlikely]]
+#define AS_LIKELY [[likely]]
+#define AS_UNLIKELY [[unlikely]]
 #else
-#define LIKELY
-#define UNLIKELY
+#define AS_LIKELY
+#define AS_UNLIKELY
 #endif
 
 #ifdef _WIN32
@@ -41,7 +41,7 @@ namespace async_simple {
 // there is a bug in the user code.
 inline void logicAssert(bool x, const char* errorMsg) {
     if (x)
-        LIKELY { return; }
+        AS_LIKELY { return; }
     throw std::logic_error(errorMsg);
 }
 

--- a/async_simple/Try.h
+++ b/async_simple/Try.h
@@ -138,7 +138,7 @@ public:
 private:
     AS_INLINE void checkHasTry() const {
         if (_contains == Contains::VALUE)
-            LIKELY { return; }
+            AS_LIKELY { return; }
         else if (_contains == Contains::EXCEPTION) {
             std::rethrow_exception(_error);
         } else if (_contains == Contains::NOTHING) {

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -261,7 +261,7 @@ struct CollectAllAwaiter {
             };
             if (Para == true && _input.size() > 1) {
                 if (exec != nullptr)
-                    LIKELY {
+                    AS_LIKELY {
                         exec->schedule(func);
                         continue;
                     }

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -148,20 +148,20 @@ public:
 public:
     T& result() & {
         if (_resultType == result_type::exception)
-            UNLIKELY { std::rethrow_exception(_exception); }
+            AS_UNLIKELY { std::rethrow_exception(_exception); }
         assert(_resultType == result_type::value);
         return _value;
     }
     T&& result() && {
         if (_resultType == result_type::exception)
-            UNLIKELY { std::rethrow_exception(_exception); }
+            AS_UNLIKELY { std::rethrow_exception(_exception); }
         assert(_resultType == result_type::value);
         return std::move(_value);
     }
 
     Try<T> tryResult() noexcept {
         if (_resultType == result_type::exception)
-            UNLIKELY { return Try<T>(_exception); }
+            AS_UNLIKELY { return Try<T>(_exception); }
         else {
             assert(_resultType == result_type::value);
             return Try<T>(std::move(_value));
@@ -187,7 +187,7 @@ public:
 
     void result() {
         if (_exception != nullptr)
-            UNLIKELY { std::rethrow_exception(_exception); }
+            AS_UNLIKELY { std::rethrow_exception(_exception); }
     }
     Try<void> tryResult() noexcept { return Try<void>(_exception); }
 

--- a/async_simple/uthread/Async.h
+++ b/async_simple/uthread/Async.h
@@ -59,7 +59,7 @@ template <class T, class F,
                                   T>::type* = nullptr>
 inline void async(F&& f, Executor* ex) {
     if (!ex)
-        UNLIKELY { return; }
+        AS_UNLIKELY { return; }
     ex->schedule([f = std::move(f), ex]() {
         Uthread uth(Attribute{ex}, std::move(f));
         uth.detach();
@@ -72,7 +72,7 @@ template <class T, class F, class C,
                                   T>::type* = nullptr>
 inline void async(F&& f, C&& c, Executor* ex) {
     if (!ex)
-        UNLIKELY { return; }
+        AS_UNLIKELY { return; }
     ex->schedule([f = std::move(f), c = std::move(c), ex]() {
         Uthread uth(Attribute{ex}, std::move(f));
         uth.join(std::move(c));

--- a/async_simple/uthread/internal/thread.cc
+++ b/async_simple/uthread/internal/thread.cc
@@ -55,7 +55,7 @@ size_t get_base_stack_size() {
 inline void jmp_buf_link::switch_in() {
     link = std::exchange(g_current_context, this);
     if (!link)
-        UNLIKELY { link = &g_unthreaded_context; }
+        AS_UNLIKELY { link = &g_unthreaded_context; }
     fcontext = _fl_jump_fcontext(fcontext, thread).fctx;
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Closes #135

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example


