### PR TITLE
Fix comparison of integer expressions of different signedness in unit…

### DIFF
--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -467,7 +467,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto out = co_await std::move(combinedLazy);
 
         CHECK_EXECUTOR(&e1);
-        EXPECT_EQ(task_num, out.size());
+        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
         co_await CurrentExecutor();
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
@@ -512,7 +512,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto out = co_await std::move(combinedLazy);
 
         CHECK_EXECUTOR(&e2);
-        EXPECT_EQ(task_num, out.size());
+        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
         co_await CurrentExecutor();
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
@@ -536,7 +536,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
 
         auto out = co_await std::move(combinedLazy);
 
-        EXPECT_EQ(task_num, out.size());
+        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
         CHECK_EXECUTOR(&e2);
         co_await CurrentExecutor();
     };
@@ -558,7 +558,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto out = co_await std::move(combinedLazy);
 
         CHECK_EXECUTOR(&e3);
-        EXPECT_EQ(task_num, out.size());
+        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
             sum += out[i].value();
@@ -581,7 +581,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         CHECK_EXECUTOR(&e3);
         auto out = co_await std::move(combinedLazy);
 
-        EXPECT_EQ(task_num, out.size());
+        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
         CHECK_EXECUTOR(&e3);
     };
     syncAwait(test3Void().via(&e3));
@@ -599,7 +599,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
             collectAllWindowed(10, false, std::move(input), outAlloc);
         CHECK_EXECUTOR(&e4);
         auto out = co_await std::move(combinedLazy);
-        EXPECT_EQ(task_num, out.size());
+        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
         CHECK_EXECUTOR(&e4);
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
@@ -633,7 +633,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto out = co_await std::move(combinedLazy);
 
         CHECK_EXECUTOR(&e6);
-        EXPECT_EQ(task_num, out.size());
+        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
             sum += out[i].value();
@@ -663,7 +663,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
 
         auto out = co_await std::move(combinedLazy);
 
-        EXPECT_EQ(task_num, out.size());
+        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
         CHECK_EXECUTOR(&e6);
     };
     syncAwait(test5Void().via(&e6));
@@ -687,7 +687,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto out = co_await std::move(combinedLazy);
 
         CHECK_EXECUTOR(&e6);
-        EXPECT_EQ(task_num, out.size());
+        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
             sum += out[i].value();
@@ -713,7 +713,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto combinedLazy = collectAllWindowed(10, false, std::move(input));
         CHECK_EXECUTOR(&e6);
         auto out = co_await std::move(combinedLazy);
-        EXPECT_EQ(task_num, out.size());
+        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
         CHECK_EXECUTOR(&e6);
     };
     syncAwait(test6Void().via(&e6));
@@ -741,7 +741,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto out = co_await std::move(combinedLazy);
 
         CHECK_EXECUTOR(&e6);
-        EXPECT_EQ(task_num, out.size());
+        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
             sum += out[i].value();
@@ -772,7 +772,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         CHECK_EXECUTOR(&e6);
         auto out = co_await std::move(combinedLazy);
 
-        EXPECT_EQ(task_num, out.size());
+        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
         CHECK_EXECUTOR(&e6);
     };
     syncAwait(test7Void().via(&e6));
@@ -800,7 +800,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto out = co_await std::move(combinedLazy);
 
         CHECK_EXECUTOR(&e6);
-        EXPECT_EQ(task_num, out.size());
+        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
             sum += out[i].value();
@@ -920,7 +920,7 @@ TEST_F(LazyTest, testCollectAllVariadic) {
         auto v_try_void01 = std::get<1>(std::move(out_tuple));
         auto v_try_void02 = std::get<2>(std::move(out_tuple));
 
-        EXPECT_EQ(2u, v_try_int.value());
+        EXPECT_EQ(2, v_try_int.value());
 
         bool b1 = std::is_same_v<Try<void>, decltype(v_try_void01)>;
         bool b2 = std::is_same_v<Try<void>, decltype(v_try_void02)>;
@@ -985,7 +985,7 @@ TEST_F(LazyTest, testCollectAllVariadic) {
         auto v_try_void01 = std::get<1>(std::move(out_tuple));
         auto v_try_void02 = std::get<2>(std::move(out_tuple));
 
-        EXPECT_EQ(2u, v_try_int.value());
+        EXPECT_EQ(2, v_try_int.value());
         bool b1 = std::is_same_v<Try<void>, decltype(v_try_void01)>;
         bool b2 = std::is_same_v<Try<void>, decltype(v_try_void02)>;
         EXPECT_TRUE(b1);
@@ -1010,7 +1010,7 @@ TEST_F(LazyTest, testCollectAllVariadic) {
         auto v_try_void01 = std::get<1>(std::move(out_tuple));
         auto v_try_void02 = std::get<2>(std::move(out_tuple));
 
-        EXPECT_EQ(2u, v_try_int.value());
+        EXPECT_EQ(2, v_try_int.value());
 
         bool b1 = std::is_same_v<Try<void>, decltype(v_try_void01)>;
         bool b2 = std::is_same_v<Try<void>, decltype(v_try_void02)>;
@@ -1061,7 +1061,7 @@ TEST_F(LazyTest, testCollectAny) {
         auto combinedLazy = collectAny(std::move(input));
         auto out = co_await std::move(combinedLazy);
         EXPECT_GT(out._value.value(), 0);
-        EXPECT_GE(out._idx, 0);
+        EXPECT_GE(out._idx, 0u);
         co_return out._value.value();
     };
     ASSERT_GT(syncAwait(test().via(&e1)), 0);
@@ -1088,7 +1088,7 @@ TEST_F(LazyTest, testCollectAny) {
         auto out = co_await std::move(combinedLazy);
 
         EXPECT_GT(out._value.value(), 10);
-        EXPECT_GE(out._idx, 0);
+        EXPECT_GE(out._idx, 0u);
         co_return out._value.value();
     };
     ASSERT_GT(syncAwait(test2().via(&e3)), 10);
@@ -1117,7 +1117,7 @@ TEST_F(LazyTest, testCollectAnyVariadic) {
         auto out = co_await std::move(combinedLazy);
         EXPECT_EQ(std::visit([](const auto& o) { return o.value() == 1; }, out),
                   true);
-        EXPECT_GE(out.index(), 0);
+        EXPECT_GE(out.index(), 0u);
         co_return out;
     };
     ASSERT_EQ(std::visit([](const auto& o) { return o.value() == 1; },
@@ -1147,7 +1147,7 @@ TEST_F(LazyTest, testCollectAnyVariadic) {
 
         EXPECT_EQ(std::visit([](const auto& o) { return o.value() == 1; }, out),
                   true);
-        EXPECT_GE(out.index(), 0);
+        EXPECT_GE(out.index(), 0u);
         co_return out;
     };
 
@@ -1166,7 +1166,7 @@ TEST_F(LazyTest, testCollectAnyVariadic) {
             getValueWithSleep(std::set<int>{1, 2, 3}, 190ms).via(&e2));
         CHECK_EXECUTOR(&e3);
         auto ret = co_await std::move(combinedLazy);
-        EXPECT_EQ(ret.index(), 2);
+        EXPECT_EQ(ret.index(), 2u);
         auto out = std::get<2>(std::move(ret));
         co_return out;
     };
@@ -1403,7 +1403,7 @@ TEST_F(LazyTest, testcollectAllParallel) {
         ss.insert(out[6].value());
         ss.insert(out[7].value());
         // FIXME: input tasks maybe run not in different thread.
-        EXPECT_GT(ss.size(), 2);
+        EXPECT_GT(ss.size(), 2u);
     };
     syncAwait(test2().via(&e1));
 }
@@ -1448,7 +1448,7 @@ TEST_F(LazyTest, testBatchedcollectAll) {
         ss.insert(out[5].value());
         ss.insert(out[6].value());
         // FIXME: input tasks maybe run not in different thread.
-        EXPECT_GT(ss.size(), 1);
+        EXPECT_GT(ss.size(), 1u);
     };
     syncAwait(test1().via(&e1));
 

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -467,7 +467,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto out = co_await std::move(combinedLazy);
 
         CHECK_EXECUTOR(&e1);
-        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
+        EXPECT_EQ(static_cast<size_t>(task_num), out.size());
         co_await CurrentExecutor();
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
@@ -512,7 +512,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto out = co_await std::move(combinedLazy);
 
         CHECK_EXECUTOR(&e2);
-        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
+        EXPECT_EQ(static_cast<size_t>(task_num), out.size());
         co_await CurrentExecutor();
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
@@ -536,7 +536,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
 
         auto out = co_await std::move(combinedLazy);
 
-        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
+        EXPECT_EQ(static_cast<size_t>(task_num), out.size());
         CHECK_EXECUTOR(&e2);
         co_await CurrentExecutor();
     };
@@ -558,7 +558,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto out = co_await std::move(combinedLazy);
 
         CHECK_EXECUTOR(&e3);
-        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
+        EXPECT_EQ(static_cast<size_t>(task_num), out.size());
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
             sum += out[i].value();
@@ -581,7 +581,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         CHECK_EXECUTOR(&e3);
         auto out = co_await std::move(combinedLazy);
 
-        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
+        EXPECT_EQ(static_cast<size_t>(task_num), out.size());
         CHECK_EXECUTOR(&e3);
     };
     syncAwait(test3Void().via(&e3));
@@ -599,7 +599,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
             collectAllWindowed(10, false, std::move(input), outAlloc);
         CHECK_EXECUTOR(&e4);
         auto out = co_await std::move(combinedLazy);
-        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
+        EXPECT_EQ(static_cast<size_t>(task_num), out.size());
         CHECK_EXECUTOR(&e4);
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
@@ -633,7 +633,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto out = co_await std::move(combinedLazy);
 
         CHECK_EXECUTOR(&e6);
-        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
+        EXPECT_EQ(static_cast<size_t>(task_num), out.size());
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
             sum += out[i].value();
@@ -663,7 +663,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
 
         auto out = co_await std::move(combinedLazy);
 
-        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
+        EXPECT_EQ(static_cast<size_t>(task_num), out.size());
         CHECK_EXECUTOR(&e6);
     };
     syncAwait(test5Void().via(&e6));
@@ -687,7 +687,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto out = co_await std::move(combinedLazy);
 
         CHECK_EXECUTOR(&e6);
-        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
+        EXPECT_EQ(static_cast<size_t>(task_num), out.size());
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
             sum += out[i].value();
@@ -713,7 +713,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto combinedLazy = collectAllWindowed(10, false, std::move(input));
         CHECK_EXECUTOR(&e6);
         auto out = co_await std::move(combinedLazy);
-        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
+        EXPECT_EQ(static_cast<size_t>(task_num), out.size());
         CHECK_EXECUTOR(&e6);
     };
     syncAwait(test6Void().via(&e6));
@@ -741,7 +741,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto out = co_await std::move(combinedLazy);
 
         CHECK_EXECUTOR(&e6);
-        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
+        EXPECT_EQ(static_cast<size_t>(task_num), out.size());
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
             sum += out[i].value();
@@ -772,7 +772,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         CHECK_EXECUTOR(&e6);
         auto out = co_await std::move(combinedLazy);
 
-        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
+        EXPECT_EQ(static_cast<size_t>(task_num), out.size());
         CHECK_EXECUTOR(&e6);
     };
     syncAwait(test7Void().via(&e6));
@@ -800,7 +800,7 @@ TEST_F(LazyTest, testCollectAllBatched) {
         auto out = co_await std::move(combinedLazy);
 
         CHECK_EXECUTOR(&e6);
-        EXPECT_EQ(static_cast<decltype(out.size())>(task_num), out.size());
+        EXPECT_EQ(static_cast<size_t>(task_num), out.size());
         int sum = 0;
         for (size_t i = 0; i < out.size(); i++) {
             sum += out[i].value();

--- a/async_simple/test/FutureTest.cpp
+++ b/async_simple/test/FutureTest.cpp
@@ -430,7 +430,8 @@ TEST_F(FutureTest, testCollectReadyFutures) {
                  .thenValue([&executed, n](vector<Try<Dummy>>&& vec) {
                      EXPECT_EQ(n, vec.size());
                      for (size_t i = 0; i < vec.size(); ++i) {
-                         EXPECT_EQ(i, vec[i].value().value);
+                         EXPECT_EQ(
+                             i, static_cast<decltype(i)>(vec[i].value().value));
                      }
                      executed = true;
                  });

--- a/async_simple/uthread/test/UthreadTest.cpp
+++ b/async_simple/uthread/test/UthreadTest.cpp
@@ -382,7 +382,7 @@ TEST_F(UthreadTest, testCollectAllSimple) {
     async<Launch::Schedule>(
         [&running, &n, ex, fs = std::move(fs)]() mutable {
             collectAll<Launch::Schedule>(fs.begin(), fs.end(), ex);
-            EXPECT_EQ(0, n);
+            EXPECT_EQ(0u, n);
             running--;
         },
         ex);

--- a/async_simple/util/test/ThreadPoolTest.cpp
+++ b/async_simple/util/test/ThreadPoolTest.cpp
@@ -72,7 +72,7 @@ using namespace async_simple::util;
 
 void TestBasic(ThreadPool& pool) {
     EXPECT_EQ(ThreadPool::ERROR_TYPE::ERROR_NONE, pool.scheduleById([] {}));
-    EXPECT_GE(pool.getItemCount(), 0);
+    EXPECT_GE(pool.getItemCount(), 0u);
 
     EXPECT_EQ(ThreadPool::ERROR_TYPE::ERROR_POOL_ITEM_IS_NULL,
               pool.scheduleById(nullptr));
@@ -83,7 +83,9 @@ void TestBasic(ThreadPool& pool) {
 
 TEST(ThreadTest, BasicTest) {
     ThreadPool pool;
-    EXPECT_EQ(std::thread::hardware_concurrency(), pool.getThreadNum());
+    EXPECT_EQ(std::thread::hardware_concurrency(),
+              static_cast<decltype(std::thread::hardware_concurrency())>(
+                  pool.getThreadNum()));
     ThreadPool pool1(2);
     EXPECT_EQ(2, pool1.getThreadNum());
 


### PR DESCRIPTION
## Why

#144 

## What is changing

Add static_cast from int to ungisned

## Example


