### PR TITLE
GH-154: Lazy & RescheduleLazy migrate to LazyBase

### DIFF
--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -22,6 +22,7 @@
 #include <async_simple/coro/ViaCoroutine.h>
 #include <async_simple/experimental/coroutine.h>
 #include <atomic>
+#include <concepts>
 #include <cstdio>
 #include <exception>
 
@@ -275,15 +276,13 @@ public:
         }
 
     private:
-        template <typename R,
-                  std::enable_if_t<!std::is_same_v<R, void>, int> = 0>
-        R awaitSuspendImpl() noexcept {
+        template <std::same_as<std::coroutine_handle<>> R>
+        auto awaitSuspendImpl() noexcept {
             return this->_handle;
         }
 
-        template <typename R,
-                  std::enable_if_t<std::is_same_v<R, void>, int> = 0>
-        R awaitSuspendImpl() noexcept {
+        template <std::same_as<void> R>
+        auto awaitSuspendImpl() noexcept {
             // executor schedule performed
             auto& pr = this->_handle.promise();
             logicAssert(pr._executor, "RescheduleLazy need executor");

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -264,7 +264,7 @@ public:
         using Base = detail::LazyAwaiterBase<T>;
         AwaiterBase(Handle coro) : Base(coro) {}
 
-        AS_INLINE void await_suspend(
+        AS_INLINE std::coroutine_handle<> await_suspend(
             std::coroutine_handle<> continuation) noexcept {
             // current coro started, caller becomes my continuation
             auto& pr = this->_handle.promise();
@@ -274,9 +274,9 @@ public:
                 logicAssert(pr._executor, "RescheduleLazy need executor");
                 pr._executor->schedule(
                     [h = this->_handle]() mutable { h.resume(); });
-            } else {
-                this->_handle.resume();
+                return std::noop_coroutine();
             }
+            return this->_handle;
         }
     };
 

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -1316,13 +1316,13 @@ Lazy<int> lazy_fn<0>() {
 TEST_F(LazyTest, testLazyPerf) {
     // The code compiled by GCC with Debug would fail
     // if test_loop is 5000.
-// #ifndef NDEBUG
+#ifndef NDEBUG
     auto test_loop = 50;
     auto expected_sum = 23250;
-// #else
-//     auto test_loop = 5000;
-//     auto expected_sum = 2325000;
-// #endif
+#else
+    auto test_loop = 5000;
+    auto expected_sum = 2325000;
+#endif
 
     auto total = 0;
 

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -1316,13 +1316,13 @@ Lazy<int> lazy_fn<0>() {
 TEST_F(LazyTest, testLazyPerf) {
     // The code compiled by GCC with Debug would fail
     // if test_loop is 5000.
-#ifndef NDEBUG
+// #ifndef NDEBUG
     auto test_loop = 50;
     auto expected_sum = 23250;
-#else
-    auto test_loop = 5000;
-    auto expected_sum = 2325000;
-#endif
+// #else
+//     auto test_loop = 5000;
+//     auto expected_sum = 2325000;
+// #endif
 
     auto total = 0;
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Closes #154 

`Lazy` and `RescheduleLazy` migrate to `LazyBase`.

## What is changing

## Example


