### PR TITLE
Fix benchmark compile fail on other platform

### DIFF
--- a/benchmarks/CallDepth.bench.cpp
+++ b/benchmarks/CallDepth.bench.cpp
@@ -18,14 +18,20 @@
 #include <async_simple/coro/Lazy.h>
 #include <async_simple/coro/SyncAwait.h>
 #include <async_simple/executors/SimpleExecutor.h>
+#ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
 #include <async_simple/uthread/Async.h>
 #include <async_simple/uthread/Collect.h>
 #include <async_simple/uthread/Uthread.h>
+#endif
 #include "ReadFileUtil.hpp"
 using namespace async_simple;
 using namespace async_simple::coro;
 using namespace async_simple::executors;
+
+#ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
 using namespace async_simple::uthread;
+#endif
+
 namespace fs = std::filesystem;
 static int core_num = 1;
 
@@ -43,6 +49,7 @@ Lazy<int> lazy_sum(int n) {
     co_return n + co_await lazy_sum(n - 1);
 }
 
+#ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
 void Uthread_call_depth_bench(benchmark::State &state) {
     using namespace async_simple::uthread;
     int n = state.range(0);
@@ -59,6 +66,7 @@ void Uthread_call_depth_bench(benchmark::State &state) {
         }
     }
 }
+#endif
 
 void Lazy_call_depth_bench(benchmark::State &state) {
     using namespace async_simple::coro;

--- a/benchmarks/ReadFile.bench.cpp
+++ b/benchmarks/ReadFile.bench.cpp
@@ -18,16 +18,23 @@
 #include <async_simple/coro/Lazy.h>
 #include <async_simple/coro/SyncAwait.h>
 #include <async_simple/executors/SimpleExecutor.h>
+#ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
 #include <async_simple/uthread/Async.h>
 #include <async_simple/uthread/Collect.h>
 #include <async_simple/uthread/Uthread.h>
+#endif
 #include "ReadFileUtil.hpp"
 using namespace async_simple;
 using namespace async_simple::coro;
 using namespace async_simple::executors;
+
+#ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
 using namespace async_simple::uthread;
-namespace fs = std::filesystem;
+#endif
+
 static int task_num = 1000;
+
+#ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
 void Uthread_read_diff_size_bench(benchmark::State &state) {
     using namespace async_simple::uthread;
     int id = state.range(0);
@@ -88,6 +95,7 @@ void Uthread_same_read_bench(benchmark::State &state) {
         }
     }
 }
+#endif
 
 void Lazy_read_diff_size_bench(benchmark::State &state) {
     using namespace async_simple::coro;
@@ -97,7 +105,7 @@ void Lazy_read_diff_size_bench(benchmark::State &state) {
     SimpleExecutor e(std::thread::hardware_concurrency());
     for (auto _ : state) {
         auto f = [&s, &e]() -> Lazy<void> {
-            std::vector<Lazy<uint64_t>> lazy_list;
+            std::vector<Lazy<size_t>> lazy_list;
             lazy_list.reserve(task_num);
             for (int i = 0; i < task_num; ++i) {
                 lazy_list.push_back(

--- a/benchmarks/ReadFileUtil.hpp
+++ b/benchmarks/ReadFileUtil.hpp
@@ -25,7 +25,9 @@
 #include <async_simple/uthread/Uthread.h>
 #endif
 #include <fcntl.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <filesystem>
 #include <fstream>
 using namespace async_simple;
@@ -81,10 +83,16 @@ Lazy<std::size_t> async_read_some(FileDescriptor fd, Buffer buffer,
 inline Lazy<std::size_t> async_read_file(const char *filename, IOExecutor *e) {
     auto buffer_size = fs::file_size(filename);
     char *buffer = new char[buffer_size];
+#ifdef _WIN32
+    int fs = -1;
+#else
     auto fd = open(filename, O_RDONLY);
+#endif
     auto size = co_await async_read_some(fd, buffer, buffer_size, 0, e);
     delete[] buffer;
+#ifndef _WIN32
     close(fd);
+#endif
     co_return size;
 }
 

--- a/benchmarks/ReadFileUtil.hpp
+++ b/benchmarks/ReadFileUtil.hpp
@@ -19,9 +19,9 @@
 #include <async_simple/coro/Lazy.h>
 #include <async_simple/coro/SyncAwait.h>
 #include <async_simple/executors/SimpleExecutor.h>
+#ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
 #include <async_simple/uthread/Async.h>
 #include <async_simple/uthread/Collect.h>
-#ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
 #include <async_simple/uthread/Uthread.h>
 #endif
 #include <fcntl.h>
@@ -31,12 +31,11 @@
 using namespace async_simple;
 using namespace async_simple::coro;
 using namespace async_simple::executors;
+namespace fs = std::filesystem;
 
 #ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
 using namespace async_simple::uthread;
-#endif
 
-namespace fs = std::filesystem;
 template <typename FileDescriptor, typename Buffer, typename Executor>
 std::size_t Uthread_read_some(FileDescriptor fd, Buffer buffer,
                               std::size_t buffer_size, std::size_t offset,
@@ -48,6 +47,7 @@ std::size_t Uthread_read_some(FileDescriptor fd, Buffer buffer,
         [&p](io_event_t event) mutable { p.setValue(event.res); });
     return uthread::await(p.getFuture().via(e));
 }
+
 inline std::size_t Uthread_read_file(const char *filename, SimpleExecutor *e) {
     auto buffer_size = fs::file_size(filename);
     char *buffer = new char[buffer_size];
@@ -58,7 +58,6 @@ inline std::size_t Uthread_read_file(const char *filename, SimpleExecutor *e) {
     return sz;
 }
 
-#ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
 void Uthread_read_file_for(int num, const std::string &s, auto e) {
     std::vector<std::function<void()>> task_list;
     task_list.reserve(num);

--- a/benchmarks/benchmark_main.cpp
+++ b/benchmarks/benchmark_main.cpp
@@ -61,10 +61,12 @@ BENCHMARK(Lazy_same_read_bench)
     ->RangeMultiplier(2)
     ->Range(2 << 4, 2 << 10)
     ->Iterations(3);
+#ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
 BENCHMARK(Uthread_call_depth_bench)
     ->RangeMultiplier(2)
     ->Range(1, 2 << 10)
     ->Iterations(3);
+#endif
 BENCHMARK(Lazy_call_depth_bench)
     ->RangeMultiplier(2)
     ->Range(1, 2 << 10)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
修复MacOS和Windows编译benchmark的错误
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example


