### PR TITLE
Replace all std::enable_if by C++20 concept

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ enable_testing()
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_library(libasync_simple INTERFACE)
+target_compile_features(libasync_simple INTERFACE cxx_std_20)
 target_include_directories(libasync_simple INTERFACE
         $<BUILD_INTERFACE:${async_simple_SOURCE_DIR}>
         $<INSTALL_INTERFACE:include>
@@ -14,7 +15,7 @@ message(STATUS "CMAKE_MODULE_PATH: ${CMAKE_MODULE_PATH}")
 
 find_package(Threads REQUIRED)
 target_link_libraries(libasync_simple INTERFACE Threads::Threads)
-find_package(Aio)
+find_package(Aio QUIET)
 
 find_package(Benchmark)
 
@@ -61,6 +62,7 @@ endif()
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     set(CXX_FLAGS
         /std:c++20
+        /Zc:__cplusplus
         /await:strict
         /EHa
         )

--- a/async_simple/Try.h
+++ b/async_simple/Try.h
@@ -209,27 +209,17 @@ private:
 
 // T is Non void
 template <typename F, typename... Args>
-std::enable_if_t<!(std::is_same<std::invoke_result_t<F, Args...>, void>::value),
-                 Try<std::invoke_result_t<F, Args...>>>
-makeTryCall(F&& f, Args&&... args) {
+auto makeTryCall(F&& f, Args&&... args) {
     using T = std::invoke_result_t<F, Args...>;
     try {
-        return Try<T>(std::forward<F>(f)(std::forward<Args>(args)...));
+        if constexpr (std::is_void_v<T>) {
+            std::forward<F>(f)(std::forward<Args>(args)...);
+            return Try<void>();
+        } else {
+            return Try<T>(std::forward<F>(f)(std::forward<Args>(args)...));
+        }
     } catch (...) {
         return Try<T>(std::current_exception());
-    }
-}
-
-// T is void
-template <typename F, typename... Args>
-std::enable_if_t<std::is_same<std::invoke_result_t<F, Args...>, void>::value,
-                 Try<void>>
-makeTryCall(F&& f, Args&&... args) {
-    try {
-        std::forward<F>(f)(std::forward<Args>(args)...);
-        return Try<void>();
-    } catch (...) {
-        return Try<void>(std::current_exception());
     }
 }
 

--- a/async_simple/coro/FutureAwaiter.h
+++ b/async_simple/coro/FutureAwaiter.h
@@ -45,6 +45,7 @@ template <typename T>
 auto operator co_await(T&& future) requires IsFuture<std::decay_t<T>>::value {
     return coro::FutureAwaiter(std::move(future));
 }
+
 }  // namespace async_simple
 
 #endif

--- a/async_simple/coro/Traits.h
+++ b/async_simple/coro/Traits.h
@@ -50,24 +50,14 @@ struct HasGlobalCoAwaitOperator<
     T, std::void_t<decltype(operator co_await(std::declval<T>()))>>
     : std::true_type {};
 
-template <typename Awaitable,
-          std::enable_if_t<HasMemberCoAwaitOperator<Awaitable>::value, int> = 0>
+template <typename Awaitable>
 auto getAwaiter(Awaitable&& awaitable) {
-    return std::forward<Awaitable>(awaitable).operator co_await();
-}
-
-template <typename Awaitable,
-          std::enable_if_t<HasGlobalCoAwaitOperator<Awaitable>::value, int> = 0>
-auto getAwaiter(Awaitable&& awaitable) {
-    return operator co_await(std::forward<Awaitable>(awaitable));
-}
-
-template <
-    typename Awaitable,
-    std::enable_if_t<!HasMemberCoAwaitOperator<Awaitable>::value, int> = 0,
-    std::enable_if_t<!HasGlobalCoAwaitOperator<Awaitable>::value, int> = 0>
-auto getAwaiter(Awaitable&& awaitable) {
-    return std::forward<Awaitable>(awaitable);
+    if constexpr (HasMemberCoAwaitOperator<Awaitable>::value)
+        return std::forward<Awaitable>(awaitable).operator co_await();
+    else if constexpr (HasGlobalCoAwaitOperator<Awaitable>::value)
+        return operator co_await(std::forward<Awaitable>(awaitable));
+    else
+        return std::forward<Awaitable>(awaitable);
 }
 
 }  // namespace detail

--- a/async_simple/coro/ViaCoroutine.h
+++ b/async_simple/coro/ViaCoroutine.h
@@ -175,20 +175,16 @@ struct [[nodiscard]] ViaAsyncAwaiter {
 // FIXME: In case awaitable is not a real awaitable, consider return
 // ReadyAwaiter instead. It would be much cheaper in case we `co_await
 // normal_function()`;
-template <
-    typename Awaitable,
-    std::enable_if_t<!detail::HasCoAwaitMethod<Awaitable>::value, int> = 0>
+template <typename Awaitable>
 inline auto coAwait(Executor* ex, Awaitable&& awaitable) {
-    using AwaiterType =
-        decltype(detail::getAwaiter(std::forward<Awaitable>(awaitable)));
-    return ViaAsyncAwaiter<std::decay_t<AwaiterType>>(
-        ex, std::forward<Awaitable>(awaitable));
-}
-
-template <typename Awaitable,
-          std::enable_if_t<detail::HasCoAwaitMethod<Awaitable>::value, int> = 0>
-inline auto coAwait(Executor* ex, Awaitable&& awaitable) {
-    return std::forward<Awaitable>(awaitable).coAwait(ex);
+    if constexpr (detail::HasCoAwaitMethod<Awaitable>::value) {
+        return std::forward<Awaitable>(awaitable).coAwait(ex);
+    } else {
+        using AwaiterType =
+            decltype(detail::getAwaiter(std::forward<Awaitable>(awaitable)));
+        return ViaAsyncAwaiter<std::decay_t<AwaiterType>>(
+            ex, std::forward<Awaitable>(awaitable));
+    }
 }
 
 }  // namespace detail

--- a/async_simple/uthread/Async.h
+++ b/async_simple/uthread/Async.h
@@ -81,6 +81,7 @@ requires(policy == Launch::Current) inline void async(F&& f, Executor* ex) {
 }
 
 }  // namespace uthread
+
 }  // namespace async_simple
 
 #endif  // ASYNC_SIMPLE_UTHREAD_ASYNC_H

--- a/async_simple/uthread/Collect.h
+++ b/async_simple/uthread/Collect.h
@@ -51,12 +51,11 @@ namespace uthread {
 // c++17, we didn't merge this two implementation by if constexpr. Merge them
 // once the codebases are ready to use c++17.
 template <Launch Policy, class Iterator>
-std::vector<typename std::enable_if<
-    !std::is_void<std::invoke_result_t<
-        typename std::iterator_traits<Iterator>::value_type>>::value,
-    std::invoke_result_t<typename std::iterator_traits<Iterator>::value_type>>::
-                type>
-collectAll(Iterator first, Iterator last, Executor* ex) {
+std::vector<
+    std::invoke_result_t<typename std::iterator_traits<Iterator>::value_type>>
+collectAll(Iterator first, Iterator last, Executor* ex) requires(
+    not std::is_void_v<std::invoke_result_t<
+        typename std::iterator_traits<Iterator>::value_type>>) {
     assert(std::distance(first, last) >= 0);
     static_assert(Policy != Launch::Prompt,
                   "collectAll not support Prompt launch policy");
@@ -94,14 +93,12 @@ collectAll(Iterator first, Iterator last, Executor* ex) {
 }
 
 template <Launch Policy, class Iterator>
-typename std::enable_if<
-    std::is_void<std::invoke_result_t<
-        typename std::iterator_traits<Iterator>::value_type>>::value,
-    void>::type
-collectAll(Iterator first, Iterator last, Executor* ex) {
+void collectAll(Iterator first, Iterator last, Executor* ex) requires(
+    std::is_void_v<std::invoke_result_t<
+        typename std::iterator_traits<Iterator>::value_type>>) {
     assert(std::distance(first, last) >= 0);
     static_assert(Launch::Prompt != Policy,
-                  "collectN not support Prompt launch policy");
+                  "collectAll not support Prompt launch policy");
 
     struct Context {
         std::atomic<std::size_t> tasks;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

The compiler output of `std::enable_if` is really ugly, and as proposed in #172, it's better to replace the old SFINAE utility function with the new C++20 `concept`.

<!-- For example: "Closes #1234" -->

Closes #172.

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

I've tried my best to replace every occurrence of `std::enable_if` in the async_simple folder. I've also merged some of the functions by `if constexpr` instead of splitting the function definitions.

(Also, don't blame me for the code style I committed, because this is not what I typically use. It was adjusted as per the clang format output in one of the Workflows, or otherwise, I can't even pass the CI tests.)