### PR TITLE
Adjust CI for MacOS

### DIFF
--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -1,0 +1,48 @@
+name: macosx
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build_with_bazel:
+    runs-on: macOS-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build
+      # Build  all program
+      working-directory: ${{github.workspace}}
+      run: bazel build --define=ASYNC_SIMPLE_DISABLE_AIO=true ...
+
+    - name: Test
+      # Execute tests
+      working-directory: ${{github.workspace}}
+      run: bazel test --define=ASYNC_SIMPLE_DISABLE_AIO=true ...
+  build_with_cmake:
+    runs-on: macOS-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: deps
+      run: brew install googletest
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: CXX=clang++ CC=clang cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      # Execute tests defined by the CMake configuration. 
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{env.BUILD_TYPE}}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
bazel 在windows上可能还会改改，先弄一下macos的
macos虽然是unix系统，但鉴于`uthread`还不支持macos,增加个CI吧
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example


