### PR TITLE
Use {async_simple} as a dependency within a Bazel project.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,0 @@
-build --cxxopt=-std=c++20
-build:windows --cxxopt=/std:c++20
-build --copt='-I.'

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_skylib//lib:selects.bzl", "selects")
+load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
 
 uthread_srcs = [
 
@@ -35,17 +35,7 @@ cc_library(
         "async_simple/coro/*.h",
         "async_simple/util/*.h"
     ]) + uthread_hdrs,
-    copts = select({
-        "@bazel_tools//platforms:windows": [
-            "/await:strict",
-            "/EHa"
-        ],
-        "//conditions:default": [
-            "-Wall",
-            "-Werror",
-            "-g",
-        ],
-    }),
+    copts = ASYNC_SIMPLE_COPTS,
     visibility = ["//visibility:public"],
     linkopts = select({
         "//bazel/config:async_simple_has_not_aio" : [],

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,3 +1,5 @@
+workspace(name = "com_github_async_simple")
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 BAZEL_SKYLIB_VERSION = "1.1.1"  # 2021-09-27
@@ -19,7 +21,6 @@ http_archive(
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz".format(version = BAZEL_SKYLIB_VERSION),
     ],
 )
-
 http_archive(
     name = "com_google_benchmark",  # 2022-07-25
     sha256 = "e0e6a0f2a5e8971198e5d382507bfe8e4be504797d75bb7aec44b5ea368fa100",

--- a/async_simple/Collect.h
+++ b/async_simple/Collect.h
@@ -16,12 +16,12 @@
 #ifndef ASYNC_SIMPLE_COLLECT_H
 #define ASYNC_SIMPLE_COLLECT_H
 
-#include <async_simple/Common.h>
-#include <async_simple/Future.h>
-#include <async_simple/Try.h>
 #include <exception>
 #include <iterator>
 #include <vector>
+#include "async_simple/Common.h"
+#include "async_simple/Future.h"
+#include "async_simple/Try.h"
 
 #include <iostream>
 

--- a/async_simple/Executor.h
+++ b/async_simple/Executor.h
@@ -16,11 +16,11 @@
 #ifndef ASYNC_SIMPLE_EXECUTOR_H
 #define ASYNC_SIMPLE_EXECUTOR_H
 
-#include <async_simple/experimental/coroutine.h>
 #include <chrono>
 #include <functional>
 #include <string>
 #include <thread>
+#include "async_simple/experimental/coroutine.h"
 
 namespace async_simple {
 // Stat information for an executor.

--- a/async_simple/Future.h
+++ b/async_simple/Future.h
@@ -16,12 +16,12 @@
 #ifndef ASYNC_SIMPLE_FUTURE_H
 #define ASYNC_SIMPLE_FUTURE_H
 
-#include <async_simple/Executor.h>
-#include <async_simple/FutureState.h>
-#include <async_simple/LocalState.h>
-#include <async_simple/Promise.h>
-#include <async_simple/Traits.h>
 #include <type_traits>
+#include "async_simple/Executor.h"
+#include "async_simple/FutureState.h"
+#include "async_simple/LocalState.h"
+#include "async_simple/Promise.h"
+#include "async_simple/Traits.h"
 
 namespace async_simple {
 

--- a/async_simple/FutureState.h
+++ b/async_simple/FutureState.h
@@ -19,16 +19,16 @@
 #include <atomic>
 #include <iostream>
 
-#include <async_simple/Common.h>
-#include <async_simple/Executor.h>
-#include <async_simple/MoveWrapper.h>
-#include <async_simple/Try.h>
 #include <cassert>
 #include <condition_variable>
 #include <functional>
 #include <mutex>
 #include <stdexcept>
 #include <thread>
+#include "async_simple/Common.h"
+#include "async_simple/Executor.h"
+#include "async_simple/MoveWrapper.h"
+#include "async_simple/Try.h"
 
 namespace async_simple {
 

--- a/async_simple/LocalState.h
+++ b/async_simple/LocalState.h
@@ -19,16 +19,16 @@
 
 #include <atomic>
 
-#include <async_simple/Common.h>
-#include <async_simple/Executor.h>
-#include <async_simple/MoveWrapper.h>
-#include <async_simple/Try.h>
 #include <condition_variable>
 #include <functional>
 #include <mutex>
 #include <stdexcept>
 #include <thread>
 #include <utility>
+#include "async_simple/Common.h"
+#include "async_simple/Executor.h"
+#include "async_simple/MoveWrapper.h"
+#include "async_simple/Try.h"
 
 namespace async_simple {
 

--- a/async_simple/MoveWrapper.h
+++ b/async_simple/MoveWrapper.h
@@ -17,8 +17,8 @@
 #ifndef ASYNC_SIMPLE_MOVEWRAPPER_H
 #define ASYNC_SIMPLE_MOVEWRAPPER_H
 
-#include <async_simple/Common.h>
 #include <exception>
+#include "async_simple/Common.h"
 
 namespace async_simple {
 

--- a/async_simple/Promise.h
+++ b/async_simple/Promise.h
@@ -16,9 +16,9 @@
 #ifndef ASYNC_SIMPLE_PROMISE_H
 #define ASYNC_SIMPLE_PROMISE_H
 
-#include <async_simple/Common.h>
-#include <async_simple/Future.h>
 #include <exception>
+#include "async_simple/Common.h"
+#include "async_simple/Future.h"
 
 namespace async_simple {
 

--- a/async_simple/Traits.h
+++ b/async_simple/Traits.h
@@ -16,10 +16,10 @@
 #ifndef ASYNC_SIMPLE_TRAITS_H
 #define ASYNC_SIMPLE_TRAITS_H
 
-#include <async_simple/Common.h>
-#include <async_simple/Try.h>
-#include <async_simple/Unit.h>
 #include <exception>
+#include "async_simple/Common.h"
+#include "async_simple/Try.h"
+#include "async_simple/Unit.h"
 
 namespace async_simple {
 

--- a/async_simple/Try.h
+++ b/async_simple/Try.h
@@ -16,12 +16,12 @@
 #ifndef ASYNC_SIMPLE_TRY_H
 #define ASYNC_SIMPLE_TRY_H
 
-#include <async_simple/Common.h>
-#include <async_simple/Unit.h>
 #include <cassert>
 #include <exception>
 #include <new>
 #include <utility>
+#include "async_simple/Common.h"
+#include "async_simple/Unit.h"
 
 namespace async_simple {
 

--- a/async_simple/Unit.h
+++ b/async_simple/Unit.h
@@ -16,9 +16,9 @@
 #ifndef ASYNC_SIMPLE_UNIT_H
 #define ASYNC_SIMPLE_UNIT_H
 
-#include <async_simple/Common.h>
-#include <async_simple/Try.h>
 #include <exception>
+#include "async_simple/Common.h"
+#include "async_simple/Try.h"
 
 namespace async_simple {
 

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -16,11 +16,6 @@
 #ifndef ASYNC_SIMPLE_CORO_COLLECT_H
 #define ASYNC_SIMPLE_CORO_COLLECT_H
 
-#include <async_simple/Common.h>
-#include <async_simple/Try.h>
-#include <async_simple/coro/CountEvent.h>
-#include <async_simple/coro/Lazy.h>
-#include <async_simple/experimental/coroutine.h>
 #include <exception>
 #include <memory>
 #include <optional>
@@ -28,6 +23,11 @@
 #include <utility>
 #include <variant>
 #include <vector>
+#include "async_simple/Common.h"
+#include "async_simple/Try.h"
+#include "async_simple/coro/CountEvent.h"
+#include "async_simple/coro/Lazy.h"
+#include "async_simple/experimental/coroutine.h"
 
 namespace async_simple {
 namespace coro {

--- a/async_simple/coro/ConditionVariable.h
+++ b/async_simple/coro/ConditionVariable.h
@@ -16,7 +16,7 @@
 #ifndef ASYNC_SIMPLE_CORO_CONDITION_VARIABLE_H
 #define ASYNC_SIMPLE_CORO_CONDITION_VARIABLE_H
 
-#include <async_simple/coro/Lazy.h>
+#include "async_simple/coro/Lazy.h"
 
 namespace async_simple {
 namespace coro {

--- a/async_simple/coro/CountEvent.h
+++ b/async_simple/coro/CountEvent.h
@@ -16,10 +16,10 @@
 #ifndef ASYNC_SIMPLE_CORO_EVENT_H
 #define ASYNC_SIMPLE_CORO_EVENT_H
 
-#include <async_simple/Common.h>
-#include <async_simple/Executor.h>
-#include <async_simple/coro/Lazy.h>
 #include <exception>
+#include "async_simple/Common.h"
+#include "async_simple/Executor.h"
+#include "async_simple/coro/Lazy.h"
 
 namespace async_simple {
 

--- a/async_simple/coro/DetachedCoroutine.h
+++ b/async_simple/coro/DetachedCoroutine.h
@@ -16,12 +16,12 @@
 #ifndef ASYNC_SIMPLE_CORO_DETACHED_COROUTINE_H
 #define ASYNC_SIMPLE_CORO_DETACHED_COROUTINE_H
 
-#include <async_simple/Common.h>
-#include <async_simple/experimental/coroutine.h>
 #include <stdio.h>
 #include <atomic>
 #include <exception>
 #include <mutex>
+#include "async_simple/Common.h"
+#include "async_simple/experimental/coroutine.h"
 
 namespace async_simple {
 

--- a/async_simple/coro/FutureAwaiter.h
+++ b/async_simple/coro/FutureAwaiter.h
@@ -16,8 +16,8 @@
 #ifndef ASYNC_SIMPLE_CORO_FUTURE_AWAITER_H
 #define ASYNC_SIMPLE_CORO_FUTURE_AWAITER_H
 
-#include <async_simple/Future.h>
-#include <async_simple/experimental/coroutine.h>
+#include "async_simple/Future.h"
+#include "async_simple/experimental/coroutine.h"
 
 namespace async_simple {
 namespace coro {

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -16,16 +16,16 @@
 #ifndef ASYNC_SIMPLE_CORO_LAZY_H
 #define ASYNC_SIMPLE_CORO_LAZY_H
 
-#include <async_simple/Common.h>
-#include <async_simple/Try.h>
-#include <async_simple/coro/DetachedCoroutine.h>
-#include <async_simple/coro/ViaCoroutine.h>
-#include <async_simple/experimental/coroutine.h>
 #include <atomic>
 #include <concepts>
 #include <cstdio>
 #include <exception>
 #include <variant>
+#include "async_simple/Common.h"
+#include "async_simple/Try.h"
+#include "async_simple/coro/DetachedCoroutine.h"
+#include "async_simple/coro/ViaCoroutine.h"
+#include "async_simple/experimental/coroutine.h"
 
 namespace async_simple {
 

--- a/async_simple/coro/Mutex.h
+++ b/async_simple/coro/Mutex.h
@@ -23,9 +23,9 @@
 #ifndef ASYNC_SIMPLE_CORO__MUTEXH
 #define ASYNC_SIMPLE_CORO__MUTEXH
 
-#include <async_simple/experimental/coroutine.h>
 #include <atomic>
 #include <mutex>
+#include "async_simple/experimental/coroutine.h"
 
 namespace async_simple {
 namespace coro {

--- a/async_simple/coro/SpinLock.h
+++ b/async_simple/coro/SpinLock.h
@@ -16,8 +16,8 @@
 #ifndef ASYNC_SIMPLE_CORO_SPIN_LOCK_H
 #define ASYNC_SIMPLE_CORO_SPIN_LOCK_H
 
-#include <async_simple/coro/Lazy.h>
 #include <thread>
+#include "async_simple/coro/Lazy.h"
 
 namespace async_simple {
 namespace coro {

--- a/async_simple/coro/SyncAwait.h
+++ b/async_simple/coro/SyncAwait.h
@@ -16,12 +16,12 @@
 #ifndef ASYNC_SIMPLE_CORO_SYNC_AWAIT_H
 #define ASYNC_SIMPLE_CORO_SYNC_AWAIT_H
 
-#include <async_simple/Common.h>
-#include <async_simple/Executor.h>
-#include <async_simple/Try.h>
-#include <async_simple/experimental/coroutine.h>
-#include <async_simple/util/Condition.h>
 #include <exception>
+#include "async_simple/Common.h"
+#include "async_simple/Executor.h"
+#include "async_simple/Try.h"
+#include "async_simple/experimental/coroutine.h"
+#include "async_simple/util/Condition.h"
 
 namespace async_simple {
 namespace coro {

--- a/async_simple/coro/Traits.h
+++ b/async_simple/coro/Traits.h
@@ -16,9 +16,9 @@
 #ifndef ASYNC_SIMPLE_CORO_TRAITS_H
 #define ASYNC_SIMPLE_CORO_TRAITS_H
 
-#include <async_simple/Common.h>
 #include <exception>
 #include <utility>
+#include "async_simple/Common.h"
 
 namespace async_simple {
 

--- a/async_simple/coro/ViaCoroutine.h
+++ b/async_simple/coro/ViaCoroutine.h
@@ -25,10 +25,10 @@
 #ifndef ASYNC_SIMPLE_CORO_VIA_COROUTINE_H
 #define ASYNC_SIMPLE_CORO_VIA_COROUTINE_H
 
-#include <async_simple/Common.h>
-#include <async_simple/Executor.h>
-#include <async_simple/coro/Traits.h>
 #include <exception>
+#include "async_simple/Common.h"
+#include "async_simple/Executor.h"
+#include "async_simple/coro/Traits.h"
 
 #include <atomic>
 #include <mutex>

--- a/async_simple/coro/test/BUILD.bazel
+++ b/async_simple/coro/test/BUILD.bazel
@@ -1,6 +1,9 @@
+load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
+
 cc_library(
     name = "hdrs_dep",
     hdrs = glob(["*.h"]),
+    copts = ASYNC_SIMPLE_COPTS,
 )
 
 cc_test(
@@ -11,4 +14,5 @@ cc_test(
         "//async_simple/test:gtest_main",
         ":hdrs_dep",
     ],  
+    copts = ASYNC_SIMPLE_COPTS,
 )

--- a/async_simple/coro/test/ConditionVariableTest.cpp
+++ b/async_simple/coro/test/ConditionVariableTest.cpp
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <async_simple/coro/ConditionVariable.h>
-#include <async_simple/coro/Lazy.h>
-#include <async_simple/coro/SpinLock.h>
-#include <async_simple/executors/SimpleExecutor.h>
-#include <async_simple/test/unittest.h>
 #include <chrono>
+#include "async_simple/coro/ConditionVariable.h"
+#include "async_simple/coro/Lazy.h"
+#include "async_simple/coro/SpinLock.h"
+#include "async_simple/executors/SimpleExecutor.h"
+#include "async_simple/test/unittest.h"
 
 using namespace std::chrono_literals;
 

--- a/async_simple/coro/test/FutureAwaiterTest.cpp
+++ b/async_simple/coro/test/FutureAwaiterTest.cpp
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <async_simple/coro/FutureAwaiter.h>
-#include <async_simple/coro/Lazy.h>
-#include <async_simple/coro/SyncAwait.h>
-#include <async_simple/test/unittest.h>
 #include <chrono>
 #include <thread>
+#include "async_simple/coro/FutureAwaiter.h"
+#include "async_simple/coro/Lazy.h"
+#include "async_simple/coro/SyncAwait.h"
+#include "async_simple/test/unittest.h"
 
 namespace async_simple {
 namespace coro {

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -23,15 +23,15 @@
 
 #include <iostream>
 
-#include <async_simple/coro/Collect.h>
-#include <async_simple/coro/Lazy.h>
-#include <async_simple/coro/SyncAwait.h>
-#include <async_simple/coro/test/Time.h>
-#include <async_simple/executors/SimpleExecutor.h>
-#include <async_simple/experimental/coroutine.h>
-#include <async_simple/test/unittest.h>
-#include <async_simple/util/Condition.h>
 #include <chrono>
+#include "async_simple/coro/Collect.h"
+#include "async_simple/coro/Lazy.h"
+#include "async_simple/coro/SyncAwait.h"
+#include "async_simple/coro/test/Time.h"
+#include "async_simple/executors/SimpleExecutor.h"
+#include "async_simple/experimental/coroutine.h"
+#include "async_simple/test/unittest.h"
+#include "async_simple/util/Condition.h"
 
 using namespace std;
 using namespace std::chrono_literals;

--- a/async_simple/coro/test/SleepTest.cpp
+++ b/async_simple/coro/test/SleepTest.cpp
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <async_simple/coro/Lazy.h>
-#include <async_simple/coro/Sleep.h>
-#include <async_simple/coro/SyncAwait.h>
-#include <async_simple/executors/SimpleExecutor.h>
-#include <async_simple/test/unittest.h>
 #include <exception>
 #include <functional>
 #include <type_traits>
+#include "async_simple/coro/Lazy.h"
+#include "async_simple/coro/Sleep.h"
+#include "async_simple/coro/SyncAwait.h"
+#include "async_simple/executors/SimpleExecutor.h"
+#include "async_simple/test/unittest.h"
 
 #include <chrono>
 #include <iostream>

--- a/async_simple/coro/test/SpinLockTest.cpp
+++ b/async_simple/coro/test/SpinLockTest.cpp
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <async_simple/coro/SpinLock.h>
-#include <async_simple/executors/SimpleExecutor.h>
-#include <async_simple/test/unittest.h>
+#include "async_simple/coro/SpinLock.h"
+#include "async_simple/executors/SimpleExecutor.h"
+#include "async_simple/test/unittest.h"
 
 namespace async_simple {
 namespace coro {

--- a/async_simple/coro/test/TraitsTest.cpp
+++ b/async_simple/coro/test/TraitsTest.cpp
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <async_simple/coro/Traits.h>
-#include <async_simple/test/unittest.h>
 #include <exception>
 #include <functional>
 #include <type_traits>
+#include "async_simple/coro/Traits.h"
+#include "async_simple/test/unittest.h"
 
 using namespace std;
 

--- a/async_simple/coro/test/ViaCoroutineTest.cpp
+++ b/async_simple/coro/test/ViaCoroutineTest.cpp
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <async_simple/coro/Lazy.h>
-#include <async_simple/coro/SyncAwait.h>
-#include <async_simple/executors/SimpleExecutor.h>
-#include <async_simple/test/unittest.h>
 #include <exception>
 #include <functional>
 #include <type_traits>
+#include "async_simple/coro/Lazy.h"
+#include "async_simple/coro/SyncAwait.h"
+#include "async_simple/executors/SimpleExecutor.h"
+#include "async_simple/test/unittest.h"
 
 #include <iostream>
 #include <thread>

--- a/async_simple/executors/SimpleExecutor.cpp
+++ b/async_simple/executors/SimpleExecutor.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <async_simple/executors/SimpleExecutor.h>
+#include "async_simple/executors/SimpleExecutor.h"
 
 namespace async_simple {
 

--- a/async_simple/executors/SimpleExecutor.h
+++ b/async_simple/executors/SimpleExecutor.h
@@ -18,9 +18,9 @@
 
 #include <functional>
 
-#include <async_simple/Executor.h>
-#include <async_simple/executors/SimpleIOExecutor.h>
-#include <async_simple/util/ThreadPool.h>
+#include "async_simple/Executor.h"
+#include "async_simple/executors/SimpleIOExecutor.h"
+#include "async_simple/util/ThreadPool.h"
 
 #include <thread>
 

--- a/async_simple/executors/SimpleIOExecutor.h
+++ b/async_simple/executors/SimpleIOExecutor.h
@@ -16,7 +16,7 @@
 #ifndef FUTURE_SIMPLE_IO_EXECUTOR_H
 #define FUTURE_SIMPLE_IO_EXECUTOR_H
 
-#include <async_simple/IOExecutor.h>
+#include "async_simple/IOExecutor.h"
 #ifndef ASYNC_SIMPLE_HAS_NOT_AIO
 #include <libaio.h>
 #endif

--- a/async_simple/executors/test/BUILD.bazel
+++ b/async_simple/executors/test/BUILD.bazel
@@ -1,3 +1,5 @@
+load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
+
 cc_test(
     name = "async_simple_executor_test",
     srcs = glob(["*.cpp"]),
@@ -5,4 +7,5 @@ cc_test(
         "//:async_simple",
         "//async_simple/test:gtest_main",
     ],  
+    copts = ASYNC_SIMPLE_COPTS,
 )

--- a/async_simple/test/BUILD.bazel
+++ b/async_simple/test/BUILD.bazel
@@ -1,9 +1,10 @@
+load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
+
 cc_library(
     name = "gtest_main",
     srcs = ["dotest.cpp"],
-    hdrs = [
-        "unittest.h",
-    ],
+    hdrs = ["unittest.h"],
     deps = ["@com_google_googletest//:gtest"],
+    copts = ASYNC_SIMPLE_COPTS,
     visibility = ["//visibility:public"],
 )

--- a/async_simple/test/FutureStateTest.cpp
+++ b/async_simple/test/FutureStateTest.cpp
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <async_simple/FutureState.h>
-#include <async_simple/executors/SimpleExecutor.h>
-#include <async_simple/test/unittest.h>
 #include <exception>
 #include <functional>
+#include "async_simple/FutureState.h"
+#include "async_simple/executors/SimpleExecutor.h"
+#include "async_simple/test/unittest.h"
 
 using namespace std;
 using namespace async_simple::executors;

--- a/async_simple/test/FutureTest.cpp
+++ b/async_simple/test/FutureTest.cpp
@@ -15,13 +15,13 @@
  */
 #include <exception>
 
-#include <async_simple/Collect.h>
-#include <async_simple/Future.h>
-#include <async_simple/executors/SimpleExecutor.h>
-#include <async_simple/test/unittest.h>
 #include <functional>
 #include <mutex>
 #include <vector>
+#include "async_simple/Collect.h"
+#include "async_simple/Future.h"
+#include "async_simple/executors/SimpleExecutor.h"
+#include "async_simple/test/unittest.h"
 
 using namespace std;
 using namespace async_simple::executors;

--- a/async_simple/test/TryTest.cpp
+++ b/async_simple/test/TryTest.cpp
@@ -15,9 +15,9 @@
  */
 #include <exception>
 
-#include <async_simple/Try.h>
-#include <async_simple/test/unittest.h>
 #include <functional>
+#include "async_simple/Try.h"
+#include "async_simple/test/unittest.h"
 
 using namespace std;
 

--- a/async_simple/uthread/Async.h
+++ b/async_simple/uthread/Async.h
@@ -34,9 +34,9 @@
 #ifndef ASYNC_SIMPLE_UTHREAD_ASYNC_H
 #define ASYNC_SIMPLE_UTHREAD_ASYNC_H
 
-#include <async_simple/uthread/Uthread.h>
 #include <memory>
 #include <type_traits>
+#include "async_simple/uthread/Uthread.h"
 
 namespace async_simple {
 namespace uthread {

--- a/async_simple/uthread/Await.h
+++ b/async_simple/uthread/Await.h
@@ -24,10 +24,10 @@
 #ifndef ASYNC_SIMPLE_UTHREAD_AWAIT_H
 #define ASYNC_SIMPLE_UTHREAD_AWAIT_H
 
-#include <async_simple/Future.h>
-#include <async_simple/coro/Lazy.h>
-#include <async_simple/uthread/internal/thread_impl.h>
 #include <type_traits>
+#include "async_simple/Future.h"
+#include "async_simple/coro/Lazy.h"
+#include "async_simple/uthread/internal/thread_impl.h"
 
 namespace async_simple {
 namespace uthread {

--- a/async_simple/uthread/Collect.h
+++ b/async_simple/uthread/Collect.h
@@ -41,10 +41,10 @@
 #ifndef ASYNC_SIMPLE_UTHREAD_COLLECT_H
 #define ASYNC_SIMPLE_UTHREAD_COLLECT_H
 
-#include <async_simple/Future.h>
-#include <async_simple/uthread/Async.h>
-#include <async_simple/uthread/Await.h>
 #include <type_traits>
+#include "async_simple/Future.h"
+#include "async_simple/uthread/Async.h"
+#include "async_simple/uthread/Await.h"
 
 namespace async_simple {
 namespace uthread {

--- a/async_simple/uthread/Latch.h
+++ b/async_simple/uthread/Latch.h
@@ -16,8 +16,8 @@
 #ifndef ASYNC_SIMPLE_UTHREAD_LATCH_H
 #define ASYNC_SIMPLE_UTHREAD_LATCH_H
 
-#include <async_simple/Future.h>
 #include <type_traits>
+#include "async_simple/Future.h"
 
 namespace async_simple {
 namespace uthread {

--- a/async_simple/uthread/Uthread.h
+++ b/async_simple/uthread/Uthread.h
@@ -16,8 +16,8 @@
 #ifndef ASYNC_SIMPLE_UTHREAD_UTHREAD_H
 #define ASYNC_SIMPLE_UTHREAD_UTHREAD_H
 
-#include <async_simple/uthread/internal/thread.h>
 #include <memory>
+#include "async_simple/uthread/internal/thread.h"
 
 namespace async_simple {
 namespace uthread {

--- a/async_simple/uthread/internal/thread.cc
+++ b/async_simple/uthread/internal/thread.cc
@@ -24,8 +24,8 @@
 #include <algorithm>
 #include <string>
 
-#include <async_simple/Common.h>
-#include <async_simple/uthread/internal/thread.h>
+#include "async_simple/Common.h"
+#include "async_simple/uthread/internal/thread.h"
 
 namespace async_simple {
 namespace uthread {

--- a/async_simple/uthread/internal/thread.h
+++ b/async_simple/uthread/internal/thread.h
@@ -27,8 +27,8 @@
 #include <memory>
 #include <type_traits>
 
-#include <async_simple/Future.h>
-#include <async_simple/uthread/internal/thread_impl.h>
+#include "async_simple/Future.h"
+#include "async_simple/uthread/internal/thread_impl.h"
 
 namespace async_simple {
 namespace uthread {

--- a/async_simple/uthread/test/BUILD.bazel
+++ b/async_simple/uthread/test/BUILD.bazel
@@ -1,3 +1,5 @@
+load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
+
 cc_test(
     name = "async_simple_uthread_test",
     srcs = select({
@@ -8,4 +10,5 @@ cc_test(
         "//:async_simple",
         "//async_simple/test:gtest_main",
     ],
+    copts = ASYNC_SIMPLE_COPTS,
 )

--- a/async_simple/uthread/test/UthreadTest.cpp
+++ b/async_simple/uthread/test/UthreadTest.cpp
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <async_simple/Common.h>
-#include <async_simple/coro/Lazy.h>
-#include <async_simple/executors/SimpleExecutor.h>
-#include <async_simple/test/unittest.h>
-#include <async_simple/uthread/Async.h>
-#include <async_simple/uthread/Await.h>
-#include <async_simple/uthread/Collect.h>
-#include <async_simple/uthread/Latch.h>
-#include <async_simple/uthread/Uthread.h>
 #include <exception>
 #include <functional>
 #include <iostream>
 #include <type_traits>
+#include "async_simple/Common.h"
+#include "async_simple/coro/Lazy.h"
+#include "async_simple/executors/SimpleExecutor.h"
+#include "async_simple/test/unittest.h"
+#include "async_simple/uthread/Async.h"
+#include "async_simple/uthread/Await.h"
+#include "async_simple/uthread/Collect.h"
+#include "async_simple/uthread/Latch.h"
+#include "async_simple/uthread/Uthread.h"
 
 using namespace std;
 

--- a/async_simple/util/ThreadPool.h
+++ b/async_simple/util/ThreadPool.h
@@ -31,7 +31,7 @@
 #include <thread>
 #include <vector>
 
-#include <async_simple/util/Queue.h>
+#include "async_simple/util/Queue.h"
 namespace async_simple::util {
 class ThreadPool {
 public:

--- a/async_simple/util/test/BUILD.bazel
+++ b/async_simple/util/test/BUILD.bazel
@@ -1,3 +1,5 @@
+load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
+
 cc_test(
     name = "async_simple_util_test",
     srcs = glob(["*.cpp"]),
@@ -5,4 +7,5 @@ cc_test(
         "//:async_simple",
         "//async_simple/test:gtest_main",
     ],
+    copts = ASYNC_SIMPLE_COPTS,
 )

--- a/bazel/config/BUILD.bazel
+++ b/bazel/config/BUILD.bazel
@@ -37,6 +37,13 @@ selects.config_setting_group(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "msvc_compiler",
+    flag_values = {
+        "@bazel_tools//tools/cpp:compiler": "msvc-cl",
+    },
+)
+
 #TODO has_not_aio
 config_setting(
     name = "has_not_aio",

--- a/bazel/config/copt.bzl
+++ b/bazel/config/copt.bzl
@@ -1,0 +1,18 @@
+ASYNC_SIMPLE_COPTS = select({
+    "//bazel/config:msvc_compiler": [
+        "/std:c++20",
+        "/await:strict",
+        "/EHa"
+    ],
+    "//conditions:default": [
+        "-std=c++20",
+        "-D_GLIBCXX_USE_CXX11_ABI=1",
+        "-Wno-deprecated-register",
+        "-fPIC",
+        "-Wall",
+        "-Werror",
+        "-D__STDC_LIMIT_MACROS",
+        "-g",
+        "-I.",
+    ],
+})

--- a/bazel/config/copt.bzl
+++ b/bazel/config/copt.bzl
@@ -13,6 +13,5 @@ ASYNC_SIMPLE_COPTS = select({
         "-Werror",
         "-D__STDC_LIMIT_MACROS",
         "-g",
-        "-I.",
     ],
 })

--- a/bazel/support/README.md
+++ b/bazel/support/README.md
@@ -1,0 +1,70 @@
+## Bazel support
+Make sure that Bazel is installed on your system.
+
+
+## Using {async_simple} as a dependency
+The following minimal example shows how to use {async_simple} as a dependency within a Bazel project.
+
+The following file structure is assumed:
+```bash
+hello-async_simple/
+├── BUILD.bazel
+├── src
+│   └── hello.cc
+└── WORKSPACE.bazel
+```
+
+*hello.cc:*
+```cpp
+#include "async_simple/uthread/Uthread.h"
+#include <iostream>
+
+int main() {
+    async_simple::uthread::Uthread uth({}, []() {
+        std::cout << "Hello async_simple!" << std::endl;
+    });
+}
+```
+The expected output of this example is `Hello async_simple!`.
+
+*WORKSPACE.bazel*:
+```python
+# Use git_repository
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "com_github_async_simple",
+    commit = "commit-id",
+    remote = "https://github.com/alibaba/async_simple.git",
+)
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+BAZEL_SKYLIB_VERSION = "1.1.1"  # 2021-09-27
+BAZEL_SKYLIB_SHA256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d"
+
+# Use http_archive
+# TODO
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = BAZEL_SKYLIB_SHA256,
+    urls = [
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz".format(version = BAZEL_SKYLIB_VERSION),
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz".format(version = BAZEL_SKYLIB_VERSION),
+    ],
+)
+```
+
+*BUILD.bazel*:
+```python
+cc_binary(
+    name = "hello",
+    srcs = ["src/hello.cc"],
+    deps = ["@com_github_async_simple//:async_simple"],
+    copts = ["-std=c++20"],
+)
+```
+
+The *BUILD* file defines a binary named `Demo` that has a dependency to {async_simple}.  
+
+To execute the binary you can run `bazel run :hello`.

--- a/benchmarks/BUILD.bazel
+++ b/benchmarks/BUILD.bazel
@@ -1,3 +1,5 @@
+load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
+
 cc_library(
     name = "benchmark_main",
     srcs = ["benchmark_main.cpp"],
@@ -10,6 +12,7 @@ cc_library(
         "//bazel/config:async_simple_with_uthread" : ["ASYNC_SIMPLE_BENCHMARK_UTHREAD"],
         "//conditions:default" : [],
     }),
+    copts = ASYNC_SIMPLE_COPTS,
 )
 
 cc_binary(
@@ -26,4 +29,5 @@ cc_binary(
         "//conditions:default": [],
     }),
     deps = [":benchmark_main"],
+    copts = ASYNC_SIMPLE_COPTS,
 )

--- a/benchmarks/CallDepth.bench.cpp
+++ b/benchmarks/CallDepth.bench.cpp
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 #include "CallDepth.bench.h"
-#include <async_simple/coro/Collect.h>
-#include <async_simple/coro/Lazy.h>
-#include <async_simple/coro/SyncAwait.h>
-#include <async_simple/executors/SimpleExecutor.h>
+#include "async_simple/coro/Collect.h"
+#include "async_simple/coro/Lazy.h"
+#include "async_simple/coro/SyncAwait.h"
+#include "async_simple/executors/SimpleExecutor.h"
 #ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
-#include <async_simple/uthread/Async.h>
-#include <async_simple/uthread/Collect.h>
-#include <async_simple/uthread/Uthread.h>
+#include "async_simple/uthread/Async.h"
+#include "async_simple/uthread/Collect.h"
+#include "async_simple/uthread/Uthread.h"
 #endif
 #include "ReadFileUtil.hpp"
 using namespace async_simple;

--- a/benchmarks/PureSwitch.bench.cpp
+++ b/benchmarks/PureSwitch.bench.cpp
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 #include "PureSwitch.bench.h"
-#include <async_simple/executors/SimpleExecutor.h>
-#include <async_simple/experimental/coroutine.h>
+#include "async_simple/executors/SimpleExecutor.h"
+#include "async_simple/experimental/coroutine.h"
 #ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
 #define private public
-#include <async_simple/uthread/Uthread.h>
+#include "async_simple/uthread/Uthread.h"
 #undef private
-#include <async_simple/uthread/Async.h>
+#include "async_simple/uthread/Async.h"
 #endif
 using namespace async_simple;
 using namespace async_simple::executors;

--- a/benchmarks/ReadFile.bench.cpp
+++ b/benchmarks/ReadFile.bench.cpp
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 #include "ReadFile.bench.h"
-#include <async_simple/coro/Collect.h>
-#include <async_simple/coro/Lazy.h>
-#include <async_simple/coro/SyncAwait.h>
-#include <async_simple/executors/SimpleExecutor.h>
+#include "async_simple/coro/Collect.h"
+#include "async_simple/coro/Lazy.h"
+#include "async_simple/coro/SyncAwait.h"
+#include "async_simple/executors/SimpleExecutor.h"
 #ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
-#include <async_simple/uthread/Async.h>
-#include <async_simple/uthread/Collect.h>
-#include <async_simple/uthread/Uthread.h>
+#include "async_simple/uthread/Async.h"
+#include "async_simple/uthread/Collect.h"
+#include "async_simple/uthread/Uthread.h"
 #endif
 #include "ReadFileUtil.hpp"
 using namespace async_simple;

--- a/benchmarks/ReadFileUtil.hpp
+++ b/benchmarks/ReadFileUtil.hpp
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-#include <async_simple/coro/Collect.h>
-#include <async_simple/coro/FutureAwaiter.h>
-#include <async_simple/coro/Lazy.h>
-#include <async_simple/coro/SyncAwait.h>
-#include <async_simple/executors/SimpleExecutor.h>
+#include "async_simple/coro/Collect.h"
+#include "async_simple/coro/FutureAwaiter.h"
+#include "async_simple/coro/Lazy.h"
+#include "async_simple/coro/SyncAwait.h"
+#include "async_simple/executors/SimpleExecutor.h"
 #ifdef ASYNC_SIMPLE_BENCHMARK_UTHREAD
-#include <async_simple/uthread/Async.h>
-#include <async_simple/uthread/Collect.h>
-#include <async_simple/uthread/Uthread.h>
+#include "async_simple/uthread/Async.h"
+#include "async_simple/uthread/Collect.h"
+#include "async_simple/uthread/Uthread.h"
 #endif
 #include <fcntl.h>
 #ifndef _WIN32


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
让使用者更好的使用bazel集成`async_simple`，需将<>替换成“”，否则编译无法通过
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing
* 更新编译选项做铺垫
* 将<>替换成""
* 增加文档

## Example


