### PR TITLE
fix: ThreadPoll benchmark assert false

### DIFF
--- a/benchmarks/ThreadPool.bench.cpp
+++ b/benchmarks/ThreadPool.bench.cpp
@@ -24,22 +24,19 @@ const int REPS = 10;
 
 void autoScheduleTasks(bool enableWorkSteal) {
     std::atomic<int> count = 0;
-    {
-        ThreadPool tp(std::thread::hardware_concurrency(), enableWorkSteal);
+    ThreadPool tp(std::thread::hardware_concurrency(), enableWorkSteal);
 
-        for (int i = 0; i < COUNT; ++i) {
-            [[maybe_unused]] auto ret = tp.scheduleById([i, &count] {
-                count++;
-                int x;
-                auto reps = REPS + (REPS * (rand() % 5));
-                for (int n = 0; n < reps; ++n)
-                    x = i + rand();
-                (void)x;
-            });
-            assert(ret == ThreadPool::ERROR_TYPE::ERROR_NONE);
-        }
+    for (int i = 0; i < COUNT; ++i) {
+        [[maybe_unused]] auto ret = tp.scheduleById([i, &count] {
+            count++;
+            int x;
+            auto reps = REPS + (REPS * (rand() % 5));
+            for (int n = 0; n < reps; ++n)
+                x = i + rand();
+            (void)x;
+        });
+        assert(ret == ThreadPool::ERROR_TYPE::ERROR_NONE);
     }
-    assert(count == COUNT);
 }
 
 void ThreadPool_noWorkSteal(benchmark::State& state) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
ThreadPoll并不会在其生命周期结束时执行完所有的任务，所以`assert`为false的可能性很大，由于`build type`为`release`时，`assert`断言触发，CI没有检测出来
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example


