### PR TITLE
add Promise forward declaration

### DIFF
--- a/async_simple/Future.h
+++ b/async_simple/Future.h
@@ -25,6 +25,9 @@
 
 namespace async_simple {
 
+template <typename T>
+class Promise;
+
 // The well-known Future/Promise pairs mimic a producer/consumer pair.
 // The Future stands for the consumer-side.
 //


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
单独`#include "async_simple/Future.h"`时，编译会报错
`Future.h`里`include`了`Promise.h`，`Promise.h`里又`include`了`Future.h`，导致单独编译`Futrue.h`时，找不到`Promise`声明而报错
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example


