### PR TITLE
Improve testCollectAny/testCollectAnyVariadic

### DIFF
--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -135,7 +135,7 @@ public:
         co_return ret;
     }
 
-    template <typename T, bool thread_id = false>
+    template <typename T>
     Lazy<T> getValueWithSleep(T x, std::chrono::microseconds msec =
                                        std::chrono::microseconds::max()) {
         struct ValueAwaiter {
@@ -163,7 +163,7 @@ public:
         co_return ret;
     }
 
-    template <typename T, bool thread_id = false>
+    template <typename T>
     Lazy<T> getValueWithCV(T x, std::condition_variable& cv, bool& ready,
                            int& cnt, std::mutex& mutex) {
         struct ValueAwaiter {

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -163,6 +163,41 @@ public:
         co_return ret;
     }
 
+    template <typename T, bool thread_id = false>
+    Lazy<T> getValueWithCV(T x, std::condition_variable& cv, bool& ready,
+                           int& cnt, std::mutex& mutex) {
+        struct ValueAwaiter {
+            T value;
+            std::condition_variable& cv;
+            bool& ready;
+            int& cnt;
+            std::mutex& mutex;
+            ValueAwaiter(T value, std::condition_variable& cv, bool& ready,
+                         int& cnt, std::mutex& mutex)
+                : value(value), cv(cv), ready(ready), cnt(cnt), mutex(mutex) {}
+
+            bool await_ready() { return false; }
+            void await_suspend(std::coroutine_handle<> continuation) noexcept {
+                std::thread([this, c = continuation]() mutable {
+                    {
+                        std::unique_lock lk(mutex);
+                        cv.wait(lk, [this]() mutable { return ready; });
+                        --cnt;
+                    }
+                    if (cnt == 0)
+                        cv.notify_one();
+                    c.resume();
+                }).detach();
+            }
+            T await_resume() noexcept { return value; }
+        };
+        auto id1 = std::this_thread::get_id();
+        auto ret = co_await ValueAwaiter(x, cv, ready, cnt, mutex);
+        auto id2 = std::this_thread::get_id();
+        EXPECT_EQ(id1, id2);
+        co_return ret;
+    }
+
     Lazy<std::thread::id> getThreadId() {
         struct ValueAwaiter {
             ValueAwaiter() {}
@@ -1036,64 +1071,86 @@ TEST_F(LazyTest, testCollectAny) {
     executors::SimpleExecutor e3(10);
 
     auto test = [this]() -> Lazy<int> {
+        auto m = std::mutex{};
+        auto is_ready = bool{false};
+        auto cnt = int{};
+        auto cv = std::condition_variable{};
         std::vector<Lazy<int>> input;
-        input.push_back(getValueWithSleep(1));
-        input.push_back(getValueWithSleep(2));
-        input.push_back(getValueWithSleep(2));
-        input.push_back(getValueWithSleep(3));
-        input.push_back(getValueWithSleep(4));
-        input.push_back(getValueWithSleep(5));
-        input.push_back(getValueWithSleep(5));
-        input.push_back(getValueWithSleep(5));
-        input.push_back(getValueWithSleep(5));
-        input.push_back(getValueWithSleep(5));
-        input.push_back(getValueWithSleep(5));
-        input.push_back(getValueWithSleep(5));
-        input.push_back(getValueWithSleep(3));
-        input.push_back(getValueWithSleep(4));
-        input.push_back(getValueWithSleep(5));
-        input.push_back(getValueWithSleep(5));
-        input.push_back(getValueWithSleep(5));
-        input.push_back(getValueWithSleep(5));
-        input.push_back(getValueWithSleep(5));
-        input.push_back(getValueWithSleep(5));
-        input.push_back(getValueWithSleep(5));
+        input.push_back(getValueWithCV(1, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(2, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(3, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(4, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(5, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(6, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(7, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(8, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(9, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(10, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(11, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(12, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(13, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(14, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(15, cv, is_ready, cnt, m));
+        input.push_back(getValueWithSleep(16, 42ms));
+        input.push_back(getValueWithCV(17, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(18, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(19, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(20, cv, is_ready, cnt, m));
+        input.push_back(getValueWithCV(21, cv, is_ready, cnt, m));
+        cnt = input.size() - 1;
         auto combinedLazy = collectAny(std::move(input));
         auto out = co_await std::move(combinedLazy);
-        EXPECT_GT(out._value.value(), 0);
-        EXPECT_GE(out._idx, 0u);
+        EXPECT_EQ(out._value.value(), 16);
+        EXPECT_EQ(out._idx, 15u);
+        {
+            std::unique_lock lk{m};
+            is_ready = true;
+            lk.unlock();
+            cv.notify_all();
+            lk.lock();
+            cv.wait(lk, [&] { return cnt == 0; });
+        }
         co_return out._value.value();
     };
-    ASSERT_GT(syncAwait(test().via(&e1)), 0);
+    ASSERT_EQ(syncAwait(test().via(&e1)), 16);
 
     auto test2 = [this, &e1, &e2, &e3]() -> Lazy<int> {
+        auto m = std::mutex{};
+        auto is_ready = bool{false};
+        auto cnt = int{};
+        auto cv = std::condition_variable{};
         std::vector<RescheduleLazy<int>> input;
-        input.push_back(getValueWithSleep(11).via(&e1));
-        input.push_back(getValueWithSleep(12).via(&e1));
-        input.push_back(getValueWithSleep(13).via(&e1));
-        input.push_back(getValueWithSleep(14).via(&e1));
-        input.push_back(getValueWithSleep(15).via(&e1));
-
-        input.push_back(getValueWithSleep(25).via(&e2));
-        input.push_back(getValueWithSleep(21).via(&e2));
-        input.push_back(getValueWithSleep(22).via(&e2));
-        input.push_back(getValueWithSleep(23).via(&e2));
-        input.push_back(getValueWithSleep(24).via(&e2));
-        input.push_back(getValueWithSleep(25).via(&e2));
-
+        input.push_back(getValueWithCV(1, cv, is_ready, cnt, m).via(&e1));
+        input.push_back(getValueWithCV(2, cv, is_ready, cnt, m).via(&e1));
+        input.push_back(getValueWithSleep(3, 65ms).via(&e1));
+        input.push_back(getValueWithCV(4, cv, is_ready, cnt, m).via(&e1));
+        input.push_back(getValueWithCV(5, cv, is_ready, cnt, m).via(&e1));
+        input.push_back(getValueWithCV(6, cv, is_ready, cnt, m).via(&e2));
+        input.push_back(getValueWithCV(7, cv, is_ready, cnt, m).via(&e2));
+        input.push_back(getValueWithCV(8, cv, is_ready, cnt, m).via(&e2));
+        input.push_back(getValueWithCV(9, cv, is_ready, cnt, m).via(&e2));
+        input.push_back(getValueWithCV(1, cv, is_ready, cnt, m).via(&e2));
+        input.push_back(getValueWithCV(1, cv, is_ready, cnt, m).via(&e2));
+        cnt = input.size() - 1;
         CHECK_EXECUTOR(&e3);
         auto combinedLazy = collectAny(std::move(input));
         CHECK_EXECUTOR(&e3);
 
         auto out = co_await std::move(combinedLazy);
 
-        EXPECT_GT(out._value.value(), 10);
-        EXPECT_GE(out._idx, 0u);
+        EXPECT_EQ(out._value.value(), 3);
+        EXPECT_EQ(out._idx, 2u);
+        {
+            std::unique_lock lk{m};
+            is_ready = true;
+            lk.unlock();
+            cv.notify_all();
+            lk.lock();
+            cv.wait(lk, [&] { return cnt == 0; });
+        }
         co_return out._value.value();
     };
-    ASSERT_GT(syncAwait(test2().via(&e3)), 10);
-
-    std::this_thread::sleep_for(chrono::seconds(2));
+    ASSERT_EQ(syncAwait(test2().via(&e3)), 3);
 }
 
 TEST_F(LazyTest, testCollectAnyVariadic) {
@@ -1108,21 +1165,35 @@ TEST_F(LazyTest, testCollectAnyVariadic) {
             async_simple::Try<long>, async_simple::Try<unsigned long>,
             async_simple::Try<long long>,
             async_simple::Try<unsigned long long>>> {
+        auto m = std::mutex{};
+        auto is_ready = bool{false};
+        auto cnt = int{7};
+        auto cv = std::condition_variable{};
         auto combinedLazy = collectAny(
-            getValueWithSleep((short)1), getValueWithSleep((unsigned short)1),
-            getValueWithSleep((int)1), getValueWithSleep((unsigned int)1),
-            getValueWithSleep((long)1), getValueWithSleep((unsigned long)1),
-            getValueWithSleep((long long)1),
-            getValueWithSleep((unsigned long long)1));
+            getValueWithCV((short)1, cv, is_ready, cnt, m),
+            getValueWithSleep((unsigned short)2),
+            getValueWithCV((int)3, cv, is_ready, cnt, m),
+            getValueWithCV((unsigned int)4, cv, is_ready, cnt, m),
+            getValueWithCV((long)5, cv, is_ready, cnt, m),
+            getValueWithCV((unsigned long)6, cv, is_ready, cnt, m),
+            getValueWithCV((long long)1, cv, is_ready, cnt, m),
+            getValueWithCV((unsigned long long)1, cv, is_ready, cnt, m));
         auto out = co_await std::move(combinedLazy);
-        EXPECT_EQ(std::visit([](const auto& o) { return o.value() == 1; }, out),
+        EXPECT_EQ(std::visit([](const auto& o) { return o.value() == 2; }, out),
                   true);
-        EXPECT_GE(out.index(), 0u);
+        {
+            std::unique_lock lk{m};
+            is_ready = true;
+            lk.unlock();
+            cv.notify_all();
+            lk.lock();
+            cv.wait(lk, [&] { return cnt == 0; });
+        }
         co_return out;
     };
-    ASSERT_EQ(std::visit([](const auto& o) { return o.value() == 1; },
+    ASSERT_EQ(std::visit([](const auto& o) { return o.value() == 2; },
                          syncAwait(test().via(&e1))),
-              1);
+              true);
 
     auto test2 = [this, &e1, &e2, &e3]()
         -> Lazy<std::variant<
@@ -1131,50 +1202,75 @@ TEST_F(LazyTest, testCollectAnyVariadic) {
             async_simple::Try<long>, async_simple::Try<unsigned long>,
             async_simple::Try<long long>,
             async_simple::Try<unsigned long long>>> {
+        auto m = std::mutex{};
+        auto is_ready = bool{false};
+        auto cnt = int{7};
+        auto cv = std::condition_variable{};
         CHECK_EXECUTOR(&e3);
-        auto combinedLazy =
-            collectAny(getValueWithSleep((short)1).via(&e1),
-                       getValueWithSleep((unsigned short)1).via(&e1),
-                       getValueWithSleep((int)1).via(&e1),
-                       getValueWithSleep((unsigned int)1).via(&e1),
-                       getValueWithSleep((long)1).via(&e2),
-                       getValueWithSleep((unsigned long)1).via(&e2),
-                       getValueWithSleep((long long)1).via(&e2),
-                       getValueWithSleep((unsigned long long)1).via(&e2));
+        auto combinedLazy = collectAny(
+            getValueWithCV((short)1, cv, is_ready, cnt, m).via(&e1),
+            getValueWithCV((unsigned short)2, cv, is_ready, cnt, m).via(&e1),
+            getValueWithCV((int)3, cv, is_ready, cnt, m).via(&e1),
+            getValueWithCV((unsigned int)4, cv, is_ready, cnt, m).via(&e1),
+            getValueWithCV((long)5, cv, is_ready, cnt, m).via(&e2),
+            getValueWithSleep((unsigned long)6, 50ms).via(&e2),
+            getValueWithCV((long long)7, cv, is_ready, cnt, m).via(&e2),
+            getValueWithCV((unsigned long long)8, cv, is_ready, cnt, m)
+                .via(&e2));
         CHECK_EXECUTOR(&e3);
-
         auto out = co_await std::move(combinedLazy);
-
-        EXPECT_EQ(std::visit([](const auto& o) { return o.value() == 1; }, out),
+        EXPECT_EQ(std::visit([](const auto& o) { return o.value() == 6; }, out),
                   true);
-        EXPECT_GE(out.index(), 0u);
+        EXPECT_EQ(out.index(), 5u);
+        {
+            std::unique_lock lk{m};
+            is_ready = true;
+            lk.unlock();
+            cv.notify_all();
+            lk.lock();
+            cv.wait(lk, [&] { return cnt == 0; });
+        }
         co_return out;
     };
 
-    ASSERT_EQ(std::visit([](const auto& o) { return o.value() == 1; },
+    ASSERT_EQ(std::visit([](const auto& o) { return o.value() == 6; },
                          syncAwait(test2().via(&e3))),
-              1);
+              true);
     using namespace std::chrono_literals;
+
     auto test3 = [this, &e1, &e2, &e3]() -> Lazy<Try<std::vector<int>>> {
+        auto m = std::mutex{};
+        auto is_ready = bool{false};
+        auto cnt = int{4};
+        auto cv = std::condition_variable{};
         CHECK_EXECUTOR(&e3);
         auto combinedLazy = collectAny(
-            getValueWithSleep(std::string("hello"), 120ms).via(&e1),
-            getValueWithSleep(std::string("hi"), 260ms).via(&e1),
+            getValueWithCV(std::string("hello"), cv, is_ready, cnt, m).via(&e1),
+            getValueWithCV(std::string("hi"), cv, is_ready, cnt, m).via(&e1),
             getValueWithSleep(std::vector<int>{1, 2, 3}, 50ms).via(&e1),
-            getValueWithSleep(std::vector<double>{1.0f, 1.5f, 204.23f}, 170ms)
+            getValueWithCV(std::vector<double>{1.0f, 1.5f, 204.23f}, cv,
+                           is_ready, cnt, m)
                 .via(&e2),
-            getValueWithSleep(std::set<int>{1, 2, 3}, 190ms).via(&e2));
+            getValueWithCV(std::set<int>{1, 2, 3}, cv, is_ready, cnt, m)
+                .via(&e2));
         CHECK_EXECUTOR(&e3);
         auto ret = co_await std::move(combinedLazy);
         EXPECT_EQ(ret.index(), 2u);
         auto out = std::get<2>(std::move(ret));
+        {
+            std::unique_lock lk{m};
+            is_ready = true;
+            lk.unlock();
+            cv.notify_all();
+            lk.lock();
+            cv.wait(lk, [&] { return cnt == 0; });
+        }
         co_return out;
     };
     auto tmp = std::vector<int>{1, 2, 3};
     auto out = syncAwait(test3().via(&e3));
     ASSERT_EQ(out.available(), true);
     ASSERT_EQ(out.value(), tmp);
-    std::this_thread::sleep_for(2000ms);
 }
 
 TEST_F(LazyTest, testException) {

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -181,7 +181,7 @@ public:
                 std::thread([this, c = continuation]() mutable {
                     {
                         std::unique_lock lk(mutex);
-                        cv.wait(lk, [this]() mutable { return ready; });
+                        cv.wait(lk, [this]() -> bool { return this->ready; });
                         --cnt;
                     }
                     if (cnt == 0)

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -179,12 +179,13 @@ public:
             bool await_ready() { return false; }
             void await_suspend(std::coroutine_handle<> continuation) noexcept {
                 std::thread([this, c = continuation]() mutable {
+                    int condition;
                     {
                         std::unique_lock lk(mutex);
                         cv.wait(lk, [this]() -> bool { return this->ready; });
-                        --cnt;
+                        condition = --cnt;
                     }
-                    if (cnt == 0)
+                    if (condition == 0)
                         cv.notify_one();
                     c.resume();
                 }).detach();


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Closes #199

## What is changing

Add getValueWithCV, with will blocked on cv.wait() until be notified, so we can ensure which work will finished first.
Then we can use condition varibale to wait the other unfinished job after CollectAny return instead of sleep a long time, which make test faster and stabler.

## Example


