### PR TITLE
Operator co_await should force to move future

### DIFF
--- a/async_simple/coro/test/FutureAwaiterTest.cpp
+++ b/async_simple/coro/test/FutureAwaiterTest.cpp
@@ -43,7 +43,7 @@ TEST_F(FutureAwaiterTest, testWithFuture) {
         auto fut = pr.getFuture();
         sum(1, 1, [pr = std::move(pr)](int val) mutable { pr.setValue(val); });
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        auto val = co_await fut;
+        auto val = co_await std::move(fut);
         EXPECT_EQ(2, val);
     };
     syncAwait(lazy1());

--- a/docs/docs.cn/Future.md
+++ b/docs/docs.cn/Future.md
@@ -136,7 +136,7 @@ Promise<int> pr;
 auto fut = pr.getFuture();
 sum(1, 1, [pr = std::move(pr)](int val) mutable { pr.setValue(val); });
 std::this_thread::sleep_for(std::chrono::milliseconds(500));
-auto val = co_await fut;
+auto val = co_await std::move(fut);
 ```
 
 如果 Future 已经设置过 Executor，那么此时当前协程的 Resumption 由该调度器控制。
@@ -148,7 +148,7 @@ Promise<int> pr;
 auto fut = pr.getFuture().via(co_await CurrentExecutor{};);
 sum(1, 1, [pr = std::move(pr)](int val) mutable { pr.setValue(val); });
 std::this_thread::sleep_for(std::chrono::milliseconds(500));
-auto val = co_await fut;
+auto val = co_await std::move(fut);
 ```
 
 ## 与有栈协程交互

--- a/docs/docs.en/Future.md
+++ b/docs/docs.en/Future.md
@@ -136,7 +136,7 @@ Promise<int> pr;
 auto fut = pr.getFuture();
 sum(1, 1, [pr = std::move(pr)](int val) mutable { pr.setValue(val); });
 std::this_thread::sleep_for(std::chrono::milliseconds(500));
-auto val = co_await fut;
+auto val = co_await std::move(fut);
 ```
 
 If the Future has set Executor already, the Executor would decide when will the Lazy to be resumed.
@@ -148,7 +148,7 @@ Promise<int> pr;
 auto fut = pr.getFuture().via(co_await CurrentExecutor{};);
 sum(1, 1, [pr = std::move(pr)](int val) mutable { pr.setValue(val); });
 std::this_thread::sleep_for(std::chrono::milliseconds(500));
-auto val = co_await fut;
+auto val = co_await std::move(fut);
 ```
 
 ## Get value from Uthread


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

```.cpp
Promise<int> pr;
auto fut = pr.getFuture();
sum(1, 1, [pr = std::move(pr)](int val) mutable { pr.setValue(val); });
auto val = co_await fut;
auto original = fut.value(); // access future again
EXPECT_EQ(val, original);
```

```.cpp
Promise<int> pr;
auto fut = pr.getFuture();
sum(1, 1, [pr = std::move(pr)](int val) mutable { pr.setValue(val); });
auto val = co_await std::move(fut);
auto original = fut.value(); // don't access future due to the object has moved
```

## What is changing

Enable access future after `co_await future`.

## Example


