### PR TITLE
allow future<void> and promise<void>

### DIFF
--- a/async_simple/Future.h
+++ b/async_simple/Future.h
@@ -49,13 +49,14 @@ class Promise;
 template <typename T>
 class Future {
 public:
-    using value_type = T;
-    Future(FutureState<T>* fs) : _sharedState(fs) {
+    using value_type = std::conditional_t<std::is_void_v<T>, Unit, T>;
+    Future(FutureState<value_type>* fs) : _sharedState(fs) {
         if (_sharedState) {
             _sharedState->attachOne();
         }
     }
-    Future(Try<T>&& t) : _sharedState(nullptr), _localState(std::move(t)) {}
+    Future(Try<value_type>&& t)
+        : _sharedState(nullptr), _localState(std::move(t)) {}
 
     ~Future() {
         if (_sharedState) {
@@ -89,13 +90,33 @@ public:
         return _localState.hasResult() || _sharedState->hasResult();
     }
 
-    T&& value() && { return std::move(result().value()); }
-    T& value() & { return result().value(); }
-    const T& value() const& { return result().value(); }
+    value_type&& value() && requires(!std::is_void_v<T>) {
+        return std::move(result().value());
+    }
+    value_type& value() & requires(!std::is_void_v<T>) {
+        return result().value();
+    }
+    const value_type& value() const& requires(!std::is_void_v<T>) {
+        return result().value();
+    }
 
-    Try<T>&& result() && { return std::move(getTry(*this)); }
-    Try<T>& result() & { return getTry(*this); }
-    const Try<T>& result() const& { return getTry(*this); }
+    void value() && requires(std::is_void_v<T>) {}
+    void value() & requires(std::is_void_v<T>) {}
+    void value() const& requires(std::is_void_v<T>) {}
+
+    Try<T>&& result() && requires(!std::is_void_v<T>) {
+        return std::move(getTry(*this));
+    }
+    Try<T>& result() & requires(!std::is_void_v<T>) { return getTry(*this); }
+    const Try<T>& result() const& requires(!std::is_void_v<T>) {
+        return getTry(*this);
+    }
+
+    Try<void> result() && requires(std::is_void_v<T>) { return Try<void>(); }
+    Try<void> result() & requires(std::is_void_v<T>) { return Try<void>(); }
+    const Try<void> result() const& requires(std::is_void_v<T>) {
+        return Try<void>();
+    }
 
     // get is only allowed on rvalue, aka, Future is not valid after get
     // invoked.
@@ -164,7 +185,11 @@ public:
     template <typename F, typename R = ValueCallableResult<T, F>>
     Future<typename R::ReturnsFuture::Inner> thenValue(F&& f) && {
         auto lambda = [func = std::forward<F>(f)](Try<T>&& t) mutable {
-            return std::forward<F>(func)(std::move(t).value());
+            if constexpr (std::is_void_v<T>) {
+                return std::forward<F>(func)();
+            } else {
+                return std::forward<F>(func)(std::move(t).value());
+            };
         };
         using Func = decltype(lambda);
         return thenImpl<Func, TryCallableResult<T, Func>>(std::move(lambda));
@@ -280,10 +305,10 @@ private:
     }
 
 private:
-    FutureState<T>* _sharedState;
+    FutureState<value_type>* _sharedState;
 
     // Ready-Future does not have a Promise, an inline state is faster.
-    LocalState<T> _localState;
+    LocalState<value_type> _localState;
 
 private:
     template <typename Iter>
@@ -305,6 +330,7 @@ template <typename T>
 Future<T> makeReadyFuture(std::exception_ptr ex) {
     return Future<T>(Try<T>(ex));
 }
+inline Future<void> makeReadyFuture() { return Future<void>(Try<Unit>()); }
 
 }  // namespace async_simple
 

--- a/async_simple/Promise.h
+++ b/async_simple/Promise.h
@@ -34,7 +34,8 @@ class Future;
 template <typename T>
 class Promise {
 public:
-    Promise() : _sharedState(new FutureState<T>()), _hasFuture(false) {
+    using value_type = std::conditional_t<std::is_void_v<T>, Unit, T>;
+    Promise() : _sharedState(new FutureState<value_type>()), _hasFuture(false) {
         _sharedState->attachPromise();
     }
     ~Promise() {
@@ -95,19 +96,24 @@ public:
 public:
     void setException(std::exception_ptr error) {
         logicAssert(valid(), "Promise is broken");
-        _sharedState->setResult(Try<T>(error));
+        _sharedState->setResult(Try<value_type>(error));
     }
-    void setValue(T&& v) {
+    void setValue(value_type&& v) requires(!std::is_void_v<T>) {
         logicAssert(valid(), "Promise is broken");
-        _sharedState->setResult(Try<T>(std::forward<T>(v)));
+        _sharedState->setResult(Try<value_type>(std::forward<T>(v)));
     }
-    void setValue(Try<T>&& t) {
+    void setValue(Try<value_type>&& t) {
         logicAssert(valid(), "Promise is broken");
         _sharedState->setResult(std::move(t));
     }
 
+    void setValue() requires(std::is_void_v<T>) {
+        logicAssert(valid(), "Promise is broken");
+        _sharedState->setResult(Try<value_type>(Unit()));
+    }
+
 private:
-    FutureState<T>* _sharedState = nullptr;
+    FutureState<value_type>* _sharedState = nullptr;
     bool _hasFuture = false;
 };
 

--- a/async_simple/Traits.h
+++ b/async_simple/Traits.h
@@ -31,11 +31,6 @@ struct IsFuture : std::false_type {
     using Inner = T;
 };
 
-template <>
-struct IsFuture<void> : std::false_type {
-    using Inner = Unit;
-};
-
 template <typename T>
 struct IsFuture<Future<T>> : std::true_type {
     using Inner = T;
@@ -51,6 +46,13 @@ struct TryCallableResult {
 template <typename T, typename F>
 struct ValueCallableResult {
     using Result = std::invoke_result_t<F, T&&>;
+    using ReturnsFuture = IsFuture<Result>;
+    static constexpr bool isTry = false;
+};
+
+template <typename F>
+struct ValueCallableResult<void, F> {
+    using Result = std::invoke_result_t<F>;
     using ReturnsFuture = IsFuture<Result>;
     static constexpr bool isTry = false;
 };

--- a/async_simple/Try.h
+++ b/async_simple/Try.h
@@ -145,8 +145,11 @@ public:
         return *this;
     }
 
+    Try& operator=(const Try<Unit>& other) { return *this; }
+
 public:
     Try(Try&& other) : _error(std::move(other._error)) {}
+    Try(Try<Unit>&& other) {}
     Try& operator=(Try&& other) {
         if (this != &other) {
             std::swap(_error, other._error);

--- a/async_simple/Try.h
+++ b/async_simple/Try.h
@@ -108,7 +108,7 @@ public:
         }
         _value.template emplace<std::exception_ptr>(error);
     }
-    std::exception_ptr getException() {
+    std::exception_ptr getException() const {
         logicAssert(std::holds_alternative<std::exception_ptr>(_value),
                     "Try object do not has on error");
         return std::get<std::exception_ptr>(_value);
@@ -145,11 +145,13 @@ public:
         return *this;
     }
 
-    Try& operator=(const Try<Unit>& other) { return *this; }
-
 public:
     Try(Try&& other) : _error(std::move(other._error)) {}
-    Try(Try<Unit>&& other) {}
+    Try(const Try<Unit>& other) {
+        if (other.hasError()) {
+            _error = other.getException();
+        }
+    }
     Try& operator=(Try&& other) {
         if (this != &other) {
             std::swap(_error, other._error);

--- a/async_simple/Try.h
+++ b/async_simple/Try.h
@@ -26,6 +26,12 @@
 
 namespace async_simple {
 
+// Forward declaration
+template <typename T>
+class Try;
+
+template <>
+class Try<void>;
 // Try<T> contains either an instance of T, an exception, or nothing.
 // Try<T>::value() will return the instance.
 // If exception or nothing inside, Try<T>::value() would throw an exception.
@@ -114,6 +120,8 @@ public:
         return std::get<std::exception_ptr>(_value);
     }
 
+    operator Try<void>() const;
+
 private:
     AS_INLINE void checkHasTry() const {
         if (std::holds_alternative<T>(_value))
@@ -147,11 +155,6 @@ public:
 
 public:
     Try(Try&& other) : _error(std::move(other._error)) {}
-    Try(const Try<Unit>& other) {
-        if (other.hasError()) {
-            _error = other.getException();
-        }
-    }
     Try& operator=(Try&& other) {
         if (this != &other) {
             std::swap(_error, other._error);
@@ -177,6 +180,14 @@ private:
 private:
     friend Try<Unit>;
 };
+
+template <class T>
+Try<T>::operator Try<void>() const {
+    if (hasError()) {
+        return Try<void>(getException());
+    }
+    return Try<void>();
+}
 
 // T is Non void
 template <typename F, typename... Args>

--- a/async_simple/uthread/Collect.h
+++ b/async_simple/uthread/Collect.h
@@ -61,11 +61,11 @@ auto collectAll(Iterator first, Iterator last, Executor* ex) {
         typename std::iterator_traits<Iterator>::value_type>;
     constexpr bool IfReturnVoid = std::is_void_v<ValueType>;
     using ResultType =
-        std::conditional_t<IfReturnVoid, Unit, std::vector<ValueType>>;
+        std::conditional_t<IfReturnVoid, void, std::vector<ValueType>>;
 
     struct Context {
         std::atomic<std::size_t> tasks;
-        ResultType result;
+        std::conditional_t<IfReturnVoid, bool, ResultType> result;
         Promise<ResultType> promise;
 
         Context(std::size_t n, Promise<ResultType>&& pr)
@@ -85,12 +85,19 @@ auto collectAll(Iterator first, Iterator last, Executor* ex) {
                     if constexpr (IfReturnVoid) {
                         f();
                         (void)i;
-                    } else
+                    } else {
                         context->result[i] = std::move(f());
+                    }
                     auto lastTasks =
                         context->tasks.fetch_sub(1u, std::memory_order_acq_rel);
-                    if (lastTasks == 1u)
-                        context->promise.setValue(std::move(context->result));
+                    if (lastTasks == 1u) {
+                        if constexpr (IfReturnVoid) {
+                            context->promise.setValue();
+                        } else {
+                            context->promise.setValue(
+                                std::move(context->result));
+                        }
+                    }
                 },
                 ex);
         }

--- a/demo_example/ReadFiles.cpp
+++ b/demo_example/ReadFiles.cpp
@@ -63,7 +63,7 @@ concept Range = requires(T &t) {
 
 // It is not travial to implement an asynchronous do_for_each.
 template <typename InputIt, typename Callable>
-Future<Unit> do_for_each(InputIt Begin, InputIt End, Callable func) {
+Future<void> do_for_each(InputIt Begin, InputIt End, Callable func) {
     for (auto It = Begin; It != End; ++It) {
         auto F = std::invoke(func, *It);
         // If we met an error, return early.
@@ -76,11 +76,11 @@ Future<Unit> do_for_each(InputIt Begin, InputIt End, Callable func) {
                 return do_for_each(SubBegin, SubEnd, func);
             });
     }
-    return makeReadyFuture(Unit());
+    return makeReadyFuture();
 }
 
 template <Range RangeTy, typename Callable>
-Future<Unit> do_for_each(const RangeTy &Rng, Callable func) {
+Future<void> do_for_each(const RangeTy &Rng, Callable func) {
     return do_for_each(Rng.begin(), Rng.end(), func);
 }
 
@@ -106,7 +106,7 @@ Future<uint64_t> CountCharInFilesAsync(const std::vector<FileName> &Files,
                            return CountCharInFileAsyncImpl(File, c).thenValue(
                                [ReadSize](auto &&Size) {
                                    *ReadSize += Size;
-                                   return makeReadyFuture(Unit());
+                                   return makeReadyFuture();
                                });
                        })
         .thenTry([ReadSize](auto &&) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
Allow `futrue<void>` and `promise<void>`
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example
```cpp
TEST_F(FutureTest, testVoidFuture) {
    Promise<void> p;
    auto f = p.getFuture();
    int i = 0;
    EXPECT_FALSE(f.hasResult());
    f.setContinuation([&i](Try<void>) { EXPECT_EQ(i, 5); });
    i = 5;
    p.setValue();
    EXPECT_TRUE(f.hasResult());

    Promise<void> p2;
    auto f2 = p2.getFuture()
                  .thenTry([](Try<void>) {

                  })
                  .thenTry([](Try<void> t) { return t.value(); })
                  .thenValue([]() { return 10; })
                  .thenValue([](int i) { EXPECT_EQ(i, 10); });
    p2.setValue();
    f2.wait();
}
```

