### PR TITLE
Upgrade github-actions environment for newer clang-format

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -9,11 +9,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2
-      with: 
+      with:
        fetch-depth: 0
     - name: install clang-format
       run:  sudo apt install clang-format


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Closes #226.

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

I think it also relates to #242 and could be a simpler fix to use the newer version of clang-format (maybe we can also use 14 which is also available and default in Jammy's APT repository).

## Example


