### PR TITLE
Fix: Deducing This is not yet implemented in gcc and clang

### DIFF
--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -72,7 +72,7 @@ struct CollectAnyResult {
 
     // Require hasError() == false. Otherwise it is UB to call
     // value() method.
-#if __cplusplus > 202002L
+#if __cpp_explicit_this_parameter >= 202110L
     template <class Self>
     auto&& value(this Self&& self) {
         return std::forward<Self>(self)._value.value();


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
我的疏忽，目前`Deducing This`这个特性在gcc和clang上还没实现，所以编译选项改成`-std=c++23`会编译错误
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example


