### PR TITLE
Set -Wno-deprecated-declarations for demo_examples in MacOS

### DIFF
--- a/demo_example/CMakeLists.txt
+++ b/demo_example/CMakeLists.txt
@@ -1,3 +1,8 @@
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(APPEND CMAKE_CXX_FLAGS_RELEASE "-Wno-deprecated-declarations")
+    set(APPEND CMAKE_CXX_FLAGS_DEBUG "-Wno-deprecated-declarations")
+endif()
+
 add_executable(CountChar CountChar.cpp)
 target_link_libraries(CountChar async_simple)
 


### PR DESCRIPTION

## Why

The CI fails on MacOS. This patch addresses this.
