### PR TITLE
Set -Wno-deprecated-declarations for demo_examples in MacOS

### DIFF
--- a/demo_example/CMakeLists.txt
+++ b/demo_example/CMakeLists.txt
@@ -1,3 +1,8 @@
+if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin" AND
+    NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
+
 add_executable(CountChar CountChar.cpp)
 target_link_libraries(CountChar async_simple)
 


### PR DESCRIPTION

The CI on MacOS may fail due to the deprecated declarations in the demo.  We can set `-Wno-xx`  option simply since it is a demo.



