### PR TITLE
fix: GCC 12 issues a spurious uninitialized-var warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,10 +115,6 @@ endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     list(APPEND CXX_FLAGS "-fcoroutines")
-    # FIXME: [GCC12 compile fail](https://github.com/alibaba/async_simple/issues/234)
-    if (CMAKE_CXX_COMPILER_VERSION MATCHES "12.*")
-        list(APPEND CXX_FLAGS "-Wno-maybe-uninitialized")
-    endif()
 endif()
 
 set(HEADERS_PATH

--- a/async_simple/FutureState.h
+++ b/async_simple/FutureState.h
@@ -195,7 +195,11 @@ public:
     //  ONLY_RESULT: promise.setValue called
     //  ONLY_CONTINUATION: future.thenImpl called
     void setResult(Try<T>&& value) {
+#if __GNUC__ != 12
+        // GCC 12 issues a spurious uninitialized-var warning.
+        // See details: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109448
         logicAssert(!hasResult(), "FutureState already has a result");
+#endif
         _try_value = std::move(value);
 
         auto state = _state.load(std::memory_order_acquire);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
Closes https://github.com/alibaba/async_simple/issues/234

之前的做法只针对cmake生效, bazel等其他编译工具无法生效
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example


