### PR TITLE
fix: gcc11.2.1 compile fail

### DIFF
--- a/async_simple/coro/test/GeneratorTest.cpp
+++ b/async_simple/coro/test/GeneratorTest.cpp
@@ -227,8 +227,10 @@ TEST_F(GeneratorTest, testIterator) {
     }
 }
 
-// FIXME: clang complile fail
 #ifndef __clang__
+#define GCC_VERSION \
+    (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#if GCC_VERSION != 110201
 
 TEST_F(GeneratorTest, testRange) {
     int j = 0;
@@ -237,6 +239,7 @@ TEST_F(GeneratorTest, testRange) {
     }
     EXPECT_EQ(j, 10);
 }
+#endif
 #endif  // __clang__
 
 TEST_F(GeneratorTest, testExample) {


### PR DESCRIPTION
```
[ 84%] Building CXX object async_simple/coro/test/CMakeFiles/async_simple_coro_test.dir/LazyTest.cpp.o
/home/fantasy-peak/async_simple/async_simple/coro/test/GeneratorTest.cpp: In member function ‘virtual void async_simple::coro::GeneratorTest_testRange_Test::TestBody()’:
/home/fantasy-peak/async_simple/async_simple/coro/test/GeneratorTest.cpp:235:26: error: no match for ‘operator|’ (operand types are ‘async_simple::coro::Generator<int>’ and ‘std::ranges::views::__adaptor::_Partial<std::ranges::views::_Take, int>’)
  235 |     for (auto i : iota() | std::views::take(10)) {
      |                   ~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~
      |                       |                    |
      |                       |                    std::ranges::views::__adaptor::_Partial<std::ranges::views::_Take, int>
      |                       async_simple::coro::Generator<int>
```