### PR TITLE
fix: makeReadyFuture

### DIFF
--- a/async_simple/Future.h
+++ b/async_simple/Future.h
@@ -349,7 +349,9 @@ template <typename T>
 Future<T> makeReadyFuture(std::exception_ptr ex) {
     return Future<T>(Try<T>(ex));
 }
-inline Future<void> makeReadyFuture() { return Future<void>(Try<Unit>()); }
+inline Future<void> makeReadyFuture() {
+    return Future<void>(Try<Unit>(Unit()));
+}
 
 }  // namespace async_simple
 

--- a/async_simple/test/FutureTest.cpp
+++ b/async_simple/test/FutureTest.cpp
@@ -516,6 +516,9 @@ TEST_F(FutureTest, testReadyFuture) {
     future.wait();
     std::move(future).via(nullptr).thenValue(
         [](int v) mutable { ASSERT_EQ(3, v); });
+    auto future2 = makeReadyFuture();
+    EXPECT_TRUE(future2.hasResult());
+    EXPECT_TRUE(future2.valid());
 }
 
 TEST_F(FutureTest, testPromiseCopy) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
在demo_example/ReadFiles.cpp这个例子中有bug，下面是原来的运行结果，可以看到，future例子没有输出
```bash
Calculating char counts synchronously.
Files contain 1586 'x' chars.
Calculating char counts asynchronously by future.
Calculating char counts asynchronously by coroutine.
Files contain 1586 'x' chars.
```
下面是更改之后的输出，我认为问题出在 makeReadyFuture 中，创建一个makeReadyFuture应该是可以通过新增加TEST断言。
```bash
Calculating char counts synchronously.
Files contain 1586 'x' chars.
Calculating char counts asynchronously by future.
Files contain 1586 'x' chars.
Calculating char counts asynchronously by coroutine.
Files contain 1586 'x' chars.
```
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

```c++
inline Future<void> makeReadyFuture() {
    return Future<void>(Try<Unit>(Unit()));
}
```

## Example
