### PR TITLE
add dispatch (#314)

### DIFF
--- a/async_simple/coro/Dispatch.h
+++ b/async_simple/coro/Dispatch.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited;
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ASYNC_SIMPLE_CORO_DISPATCH_H
+#define ASYNC_SIMPLE_CORO_DISPATCH_H
+
+#include "async_simple/Common.h"
+#include "async_simple/Executor.h"
+#include "async_simple/coro/Lazy.h"
+#include "async_simple/experimental/coroutine.h"
+
+#include <cassert>
+#include <type_traits>
+
+namespace async_simple {
+namespace coro {
+
+namespace detail {
+
+// based on c++ coroutine common abi.
+// it is not supported that the PromiseType's align is larger than the size of
+// two function pointer.
+inline std::coroutine_handle<> GetContinuationFromHandle(
+    std::coroutine_handle<> h) {
+    constexpr size_t promise_offset = 2 * sizeof(void*);
+    char* ptr = static_cast<char*>(h.address());
+    ptr = ptr + promise_offset;
+    return std::coroutine_handle<>::from_address(
+        *static_cast<void**>(static_cast<void*>(ptr)));
+}
+
+inline void ChangeLaziessExecutorTo(std::coroutine_handle<> h, Executor* ex) {
+    while (true) {
+        std::coroutine_handle<> continuation = GetContinuationFromHandle(h);
+        if (!continuation.address()) {
+            break;
+        }
+        auto& promise =
+            std::coroutine_handle<LazyPromiseBase>::from_address(h.address())
+                .promise();
+        promise._executor = ex;
+        h = continuation;
+    }
+}
+
+class DispatchAwaiter {
+public:
+    explicit DispatchAwaiter(Executor* ex) noexcept : _ex(ex) {
+        assert(_ex != nullptr);
+    }
+
+    bool await_ready() const noexcept { return false; }
+
+    template <typename PromiseType>
+    bool await_suspend(std::coroutine_handle<PromiseType> h) {
+        static_assert(std::is_base_of<LazyPromiseBase, PromiseType>::value,
+                      "dispatch is only allowed to be called by Lazy");
+        if (h.promise()._executor == _ex) {
+            return false;
+        }
+        Executor* old_ex = h.promise()._executor;
+        ChangeLaziessExecutorTo(h, _ex);
+        bool succ = _ex->schedule(std::move(h));
+        // cannot access *this after schedule.
+        // If the scheduling fails, we must change the executor back to its
+        // original value, as the user may catch exceptions and handle them
+        // themselves, which can result in inconsistencies between the executor
+        // recorded by Lazy and the actual executor running.
+        if (succ == false)
+            AS_UNLIKELY {
+                ChangeLaziessExecutorTo(h, old_ex);
+                throw std::runtime_error("dispatch to executor failed");
+            }
+        return true;
+    }
+
+    void await_resume() noexcept {}
+
+private:
+    Executor* _ex;
+};
+
+class DispatchAwaitable {
+public:
+    explicit DispatchAwaitable(Executor* ex) : _ex(ex) {}
+
+    auto coAwait(Executor*) { return DispatchAwaiter(_ex); }
+
+private:
+    Executor* _ex;
+};
+
+}  // namespace detail
+
+// schedule this Lazy to ex for execution
+inline detail::DispatchAwaitable dispatch(Executor* ex) {
+    logicAssert(ex != nullptr, "dispatch's param should not be nullptr");
+    return detail::DispatchAwaitable(ex);
+}
+
+}  // namespace coro
+}  // namespace async_simple
+
+#endif

--- a/async_simple/coro/test/DispatchTest.cpp
+++ b/async_simple/coro/test/DispatchTest.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited;
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "async_simple/coro/Dispatch.h"
+#include "async_simple/coro/Lazy.h"
+#include "async_simple/coro/SyncAwait.h"
+#include "async_simple/executors/SimpleExecutor.h"
+#include "async_simple/test/unittest.h"
+
+namespace async_simple::coro {
+
+struct alignas(4) AlignTest {
+    int i;
+};
+
+TEST(DispatchTest, testDispatch) {
+    async_simple::executors::SimpleExecutor executor1(2);
+    async_simple::executors::SimpleExecutor executor2(2);
+    auto task = [&]() -> Lazy<> {
+        Executor* ex = co_await CurrentExecutor{};
+        EXPECT_EQ(ex, &executor1);
+        co_await dispatch(&executor1);
+        ex = co_await CurrentExecutor{};
+        EXPECT_EQ(ex, &executor1);
+        co_await dispatch(&executor2);
+        ex = co_await CurrentExecutor{};
+        EXPECT_EQ(ex, &executor2);
+    };
+    async_simple::coro::syncAwait(task().via(&executor1));
+
+    auto task1 = [&]() -> Lazy<AlignTest> {
+        Executor* ex = co_await CurrentExecutor{};
+        EXPECT_EQ(ex, &executor1);
+        co_await dispatch(&executor2);
+        ex = co_await CurrentExecutor{};
+        EXPECT_EQ(ex, &executor2);
+        co_return AlignTest{2};
+    };
+
+    auto task2 = [&]() -> Lazy<> {
+        Executor* ex = co_await CurrentExecutor{};
+        EXPECT_EQ(ex, &executor1);
+        AlignTest t = co_await task1();
+        EXPECT_EQ(t.i, 2);
+        ex = co_await CurrentExecutor{};
+        EXPECT_EQ(ex, &executor2);
+    };
+    async_simple::coro::syncAwait(task2().via(&executor1));
+}
+
+}  // namespace async_simple::coro

--- a/docs/docs.cn/dispatch.md
+++ b/docs/docs.cn/dispatch.md
@@ -1,0 +1,26 @@
+# dispatch
+
+通过使用dispatch函数可以将当前Lazy调度到指定Executor上执行，为用户提供了便捷的接口。例如当用户需要将某个操作调度到不同的Executor上执行时，如果没有dispatch函数，则需要生成新的Lazy并将必须的资源转移到新Lazy中以调度执行，dispatch可以减少这些损耗。
+
+## 用法
+```c++
+#include "async_simple/coro/Dispatch.h"
+
+using namespace async_simple::coro;
+
+Lazy<> work() {
+  //...
+  Executor* my_ex = co_await CurrentExecutor{};
+  assert(my_ex == &executor1);
+  co_await dispatch(&executor2);
+  my_ex = co_await CurrentExecutor{};
+  assert(my_ex == &executor2);
+}
+
+syncAwait(work2().via(&executor1));
+
+```
+
+## 说明
+* 如果dispatch指定的Executor就是当前Executor，则会继续执行，不会导致重新调度。
+* 如果dispatch指定的Executor调度失败（schedule返回false），则会抛出`std::runtime_error("dispatch to executor failed")`异常。

--- a/docs/docs.en/dispatch.md
+++ b/docs/docs.en/dispatch.md
@@ -1,0 +1,26 @@
+# dispatch
+
+By using the dispatch function, the current Lazy can be scheduled to execute on the specified Executor, which provides a convenient interface for users. For example, when a user needs to schedule an operation to a different Executor for execution, if there is no dispatch function, a new Lazy needs to be generated and necessary resources transferred to the new Lazy. The dispatch function can reduce these losses.
+
+## Usage
+```c++
+#include "async_simple/coro/Dispatch.h"
+
+using namespace async_simple::coro;
+
+Lazy<> work() {
+  //...
+  Executor* my_ex = co_await CurrentExecutor{};
+  assert(my_ex == &executor1);
+  co_await dispatch(&executor2);
+  my_ex = co_await CurrentExecutor{};
+  assert(my_ex == &executor2);
+}
+
+syncAwait(work2().via(&executor1));
+
+```
+
+## Illustrate
+* If the executor specified in the dispatch is the current executor, execution will continue without causing a rescheduling.
+* If the dispatch specified Executor fails to schedule (the `schedule` interface returns false), an exception `std::runtime_error("dispatch to executor failed")`will be thrown.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

支持通过 `co_await dispatch(executor) `将本协程调度到对应的executor上执行

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

- `LazyPromiseBase `加了一个数据成员 `_caller_detached_coroutine`，用来标识caller协程是否为DetachedCoroutine。`_continuation`被类型擦除了，而我们需要运行时更新caller协程的executor，因此需要一个flag区分不同的promise类型并执行运行时转换。
- 新增一个接口函数：` DispatchAwaitable dispatch(Executor* ex)`

## Example
```c++
TEST(DispatchTest, testDispatch) {
    async_simple::executors::SimpleExecutor executor1(2);
    async_simple::executors::SimpleExecutor executor2(2);
    auto task = [&]() -> Lazy<> {
        Executor* ex = co_await CurrentExecutor{};
        EXPECT_EQ(ex, &executor1);
        co_await dispatch(&executor1);
        EXPECT_EQ(ex, &executor1);
        co_await dispatch(&executor2);
        ex = co_await CurrentExecutor{};
        EXPECT_EQ(ex, &executor2);
    };
    async_simple::coro::syncAwait(task().via(&executor1));
}
```