### PR TITLE
Fix GCC build failures

### DIFF
--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <concepts>
+#include <cstddef>
 #include <cstdio>
 #include <exception>
 #include <variant>
@@ -128,7 +129,7 @@ public:
 template <typename T>
 class LazyPromise : public LazyPromiseBase {
 public:
-    static_assert(alignof(T) <= alignof(std::max_align_t),
+    static_assert(alignof(T) <= alignof(::max_align_t),
                   "async_simple doesn't allow Lazy with over aligned object");
 
     LazyPromise() noexcept {}


### PR DESCRIPTION
The CI shows that GCC doesn't know about `std::max_align_t`. This should be a GCC's bug. Use `::max_align_t` to workaround this.
