### PR TITLE
improve cmake support for msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,10 @@ if(${ASYNC_SIMPLE_BUILD_MODULES})
         include(cxx_modules_rules_clang.cmake)
     endif()
 
+    if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+        set(CMAKE_EXPERIMENTAL_CXX_MODULE_DYNDEP 1)
+    endif()
+
     set(CMAKE_CXX_STANDARD 20)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
     set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Fix this error

```
$ cmake -DASYNC_SIMPLE_BUILD_MODULES=ON -G Ninja ..

-- Skipping benchmarks
-- Configuring done (16.1s)
CMake Error in modules/CMakeLists.txt:
  The "async_simple_modules" target has C++ module sources but its
  experimental support has not been requested


-- Generating done (0.1s)
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

https://github.com/alibaba/async_simple/pull/320#issuecomment-1579825152

## What is changing

## Example


