### PR TITLE
fix: ensure coAwait returns awaiter object; add include cassert

### DIFF
--- a/async_simple/coro/ViaCoroutine.h
+++ b/async_simple/coro/ViaCoroutine.h
@@ -31,6 +31,7 @@
 #include "async_simple/coro/Traits.h"
 
 #include <atomic>
+#include <cassert>
 #include <mutex>
 #include <utility>
 
@@ -175,7 +176,8 @@ struct [[nodiscard]] ViaAsyncAwaiter {
 template <typename Awaitable>
 inline auto coAwait(Executor* ex, Awaitable&& awaitable) {
     if constexpr (detail::HasCoAwaitMethod<Awaitable>) {
-        return std::forward<Awaitable>(awaitable).coAwait(ex);
+        return detail::getAwaiter(
+            std::forward<Awaitable>(awaitable).coAwait(ex));
     } else {
         using AwaiterType =
             decltype(detail::getAwaiter(std::forward<Awaitable>(awaitable)));


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
因为Future的coAwait函数返回的是Awaitable对象，因此需要修改detail::coAwait函数使其确定性的返回Awaiter对象，在抽象层上保证语义不变。
（如果要Future的coAwait函数返回Awaiter对象，那么Future.h和FutureAwaiter.h就是相互包含的，比较难搞）

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example


