### PR TITLE
fix: benchmark::DoNotOptimize(const Tp&) is deprecated

### DIFF
--- a/benchmarks/PureSwitch.bench.cpp
+++ b/benchmarks/PureSwitch.bench.cpp
@@ -68,8 +68,8 @@ void Generator_pure_switch_bench(benchmark::State &state) {
     for (auto _ : state) {
         auto g = f();
         for (int i = 0; i < num; ++i) {
-            benchmark::DoNotOptimize(g());
-            // g();
+            int value = g();
+            benchmark::DoNotOptimize(value);
         }
     }
 }


### PR DESCRIPTION
The const-ref version of this method can permit undesired compiler optimizations in benchmarks



