### PR TITLE
Compile benchmarks in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,6 +30,7 @@ jobs:
            sudo mkdir build && cd build
            sudo cmake .. && sudo make
            sudo apt install libgmock-dev -y
+           sudo apt install libbenchmark-dev -y
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.


### PR DESCRIPTION
While we don't run benchmarks now, it is still worth to compile the benchmarks in CI.
