### PR TITLE
build: fix bazel build bug

### DIFF
--- a/bazel/config/copt.bzl
+++ b/bazel/config/copt.bzl
@@ -1,5 +1,5 @@
 ASYNC_SIMPLE_COPTS = select({
-    "//bazel/config:msvc_compiler": [
+    "@com_github_async_simple//bazel/config:msvc_compiler": [
         "/std:c++20",
         "/await:strict",
         "/EHa"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
```
ASYNC_SIMPLE_COPTS = select({
    # 这里需要显式指定@com_github_async_simple
    "@com_github_async_simple//bazel/config:msvc_compiler": [
        "/std:c++20",
        "/await:strict",
        "/EHa"
    ],
    "//conditions:default": [
        "-std=c++20",
        "-D_GLIBCXX_USE_CXX11_ABI=1",
        "-Wno-deprecated-register",
        "-Wno-mismatched-new-delete",
        "-fPIC",
        "-Wall",
        "-Werror",
        "-D__STDC_LIMIT_MACROS",
        "-g",
    ],
})
```
假设一项目依赖async_simple:
```
package(default_visibility = ["//visibility:public"])

load("@com_github_async_simple//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")

cc_test(
  name = "test",
  srcs = glob(["test/*.cc", "test/*.h"]),
  includes = ["test"],
  copts = ASYNC_SIMPLE_COPTS,
  deps = [
    "@googletest//:gtest",
    "@googletest//:gtest_main",
    "@com_github_async_simple//:async_simple",
  ]
)
```
如果不在`ASYNC_SIMPLE_COPTS`的定义里显式指定Repository的话构建会失败：

ERROR: Analysis of target '//:test' failed; build aborted: no such package 'bazel/config': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.

bazel version: 6.0.0

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example


