### PR TITLE
fix: update CMakeLists for AppleClang 15.x Support

### DIFF
--- a/async_simple/coro/test/CMakeLists.txt
+++ b/async_simple/coro/test/CMakeLists.txt
@@ -2,10 +2,13 @@ file(GLOB coro_test_src "*.cpp")
 add_executable(async_simple_coro_test ${coro_test_src} ${PROJECT_SOURCE_DIR}/async_simple/test/dotest.cpp)
 
 target_link_libraries(async_simple_coro_test async_simple ${deplibs} ${testdeplibs})
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 15)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND
+    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "15.0" AND
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0")
     # Clang gives incorrect warnings, See https://github.com/llvm/llvm-project/issues/56768
-    target_compile_options(async_simple_coro_test PUBLIC -Wno-unsequenced)
+    message("Applying -Wno-unsequenced to async_simple_coro_test for Clang 15.x")
+    target_compile_options(async_simple_coro_test PRIVATE -Wno-unsequenced)
 endif()
 
 add_test(NAME run_async_simple_coro_test COMMAND async_simple_coro_test)
-


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

The current CMake settings do not specifically address AppleClang 15.x versions, which is needed to handle certain compiler errors.

macos 14.2.1 (m2) version of clang:
```
message("Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
message("Compiler Version: ${CMAKE_CXX_COMPILER_VERSION}") 

# Compiler ID: AppleClang
# Compiler Version: 15.0.0.15000040
```

## What is changing

Added a condition in CMakeLists.txt to apply the -Wno-unsequenced option specifically for AppleClang 15.x



