### PR TITLE
[fix] fix compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,6 @@ else()
         -Wno-deprecated-register
         -Wno-mismatched-new-delete
         -Wno-deprecated-declarations
-        -Wno-unused-value
         -D_FILE_OFFSET_BITS=64
         -fPIC
         -Wall
@@ -71,6 +70,10 @@ else()
         -D__STDC_LIMIT_MACROS
         -g
         )
+    if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.3)
+        message(STATUS "append -unused-value when gcc version is less equal than 10.2.")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-value")
+    endif()
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         list(APPEND CXX_FLAGS -Wno-uninitialized)
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ else()
         -Wno-deprecated-register
         -Wno-mismatched-new-delete
         -Wno-deprecated-declarations
+        -Wno-unused-value
         -D_FILE_OFFSET_BITS=64
         -fPIC
         -Wall

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -66,9 +66,7 @@ struct CollectAnyResult {
     bool hasError() const { return _value.hasError(); }
     // Require hasError() == true. Otherwise it is UB to call
     // this method.
-    std::exception_ptr getException() const {
-        return _value.getException();
-    }
+    std::exception_ptr getException() const { return _value.getException(); }
 
     // Require hasError() == false. Otherwise it is UB to call
     // value() method.
@@ -371,7 +369,9 @@ inline auto collectAllWindowedImpl(size_t maxConcurrency,
     }
     size_t start = 0;
     while (start < input_size) {
-        size_t end = (std::min)(input_size, start + maxConcurrency);
+        size_t end = (std::min)(
+            input_size,
+            start + maxConcurrency);  // Avoid to conflict with Windows macros.
         std::vector<LazyType> tmp_group(
             std::make_move_iterator(input.begin() + start),
             std::make_move_iterator(input.begin() + end));

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -371,7 +371,7 @@ inline auto collectAllWindowedImpl(size_t maxConcurrency,
     }
     size_t start = 0;
     while (start < input_size) {
-        size_t end = std::min(input_size, start + maxConcurrency);
+        size_t end = (std::min)(input_size, start + maxConcurrency);
         std::vector<LazyType> tmp_group(
             std::make_move_iterator(input.begin() + start),
             std::make_move_iterator(input.begin() + end));

--- a/async_simple/coro/test/GeneratorTest.cpp
+++ b/async_simple/coro/test/GeneratorTest.cpp
@@ -229,7 +229,9 @@ TEST_F(GeneratorTest, testIterator) {
 
 // FIXME: clang complile fail
 #ifndef __clang__
-
+#ifdef __GNUC__
+#include <features.h>
+#if __GNUC_PREREQ(10, 3)  // If  gcc_version >= 10.3
 TEST_F(GeneratorTest, testRange) {
     int j = 0;
     for (auto i : iota() | std::views::take(10)) {
@@ -237,6 +239,8 @@ TEST_F(GeneratorTest, testRange) {
     }
     EXPECT_EQ(j, 10);
 }
+#endif
+#endif
 #endif  // __clang__
 
 TEST_F(GeneratorTest, testExample) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

fix compile error on gcc10.2 or lower version;

fix compile error on msvc;

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

add no-unused-value when gcc10.2 or lower;

use (std::min) instead of std::min to avoid conflict on windows;

## Example


