### PR TITLE
Add workaround for Clang 15 compatibility in Generator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Required Compiler: clang (>= 10.0.0) or gcc (>= 10.3) or Apple-clang (>= 14)
 
 Note that we need to add the `-Wno-maybe-uninitialized` option when we use gcc 12 due to a false positive diagnostic message by gcc 12
 
-Note that when using clang 15 it may be necessary to add the `-Wno-unsequenced` option, which is a false positive of clang 15. See https://github.com/llvm/llvm-project/issues/56768 for details. If you're using `async_simple::Generator`, there may be some compiler bugs in clang15. We suggest to use clang17 or higher for that.
+If you're using `async_simple::Generator`, there may be some compiler bugs in clang15. We suggest to use clang17 or higher for that.
 
 If you meet any problem about MSVC Compiler Error C4737. Try to add the /EHa option to fix the problem.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -71,7 +71,7 @@ async\_simple 涉及 C++20 协程，对编译器版本有较高要求。需要 c
 
 注意当使用 gcc12 时需要加上 `-Wno-maybe-uninitialized` 选项因为 gcc12 的一个误报。详情可见 https://github.com/alibaba/async_simple/issues/234。
 
-注意当使用 clang15 时可能需要加上 `-Wno-unsequenced` 选项，这是clang15的一个误报。详情可见 https://github.com/llvm/llvm-project/issues/56768。若你需要使用 `async_simple::Generator`，我们推荐使用 clang17 或更高的版本因为在低版本 clang 上存在一些关于 Generator 的 bug report。
+若你需要使用 `async_simple::Generator`，我们推荐使用 clang17 或更高的版本因为在低版本 clang 上存在一些关于 Generator 的 bug report。
 
 注意，如果使用msvc时遇到了C4737错误，请加上选项/EHa。
 

--- a/async_simple/coro/Generator.h
+++ b/async_simple/coro/Generator.h
@@ -17,6 +17,11 @@
 #ifndef ASYNC_SIMPLE_CORO_GENERATOR_H
 #define ASYNC_SIMPLE_CORO_GENERATOR_H
 
+#if defined(__clang__) && __clang_major__ == 15
+// See: https://github.com/alibaba/async_simple/issues/372
+#warning "Clang 15 is not supported for Generator due to some issues."
+#endif
+
 #if __has_include(<generator>)
 
 #include <generator>

--- a/async_simple/coro/test/CMakeLists.txt
+++ b/async_simple/coro/test/CMakeLists.txt
@@ -3,12 +3,4 @@ add_executable(async_simple_coro_test ${coro_test_src} ${PROJECT_SOURCE_DIR}/asy
 
 target_link_libraries(async_simple_coro_test async_simple ${deplibs} ${testdeplibs})
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "15.0" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0")
-    # Clang gives incorrect warnings, See https://github.com/llvm/llvm-project/issues/56768
-    message("Applying -Wno-unsequenced to async_simple_coro_test for Clang 15.x")
-    target_compile_options(async_simple_coro_test PRIVATE -Wno-unsequenced)
-endif()
-
 add_test(NAME run_async_simple_coro_test COMMAND async_simple_coro_test)

--- a/async_simple/coro/test/GeneratorTest.cpp
+++ b/async_simple/coro/test/GeneratorTest.cpp
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+#if defined(__clang__) && __clang_major__ == 15
+// See: https://github.com/alibaba/async_simple/issues/372
+#define SKIP_GENERATOR_TEST
+#endif
+
+#ifndef SKIP_GENERATOR_TEST
+
 #include <algorithm>
 #include <array>
 #include <iostream>
@@ -398,3 +405,5 @@ TEST_F(GeneratorTest, testNoCopyClass) {
 }
 
 }  // namespace async_simple::coro
+
+#endif  // SKIP_GENERATOR_TEST


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Closes #372.

## Changes: 
- Generator.h and GeneratorTest.cpp: If the user is using Clang-15, skip compiling GeneratorTest.cpp directly and add a compilation warning in Generator.h.
- README.md and README_CN.md: Removing specific mentions of Clang-15 compiler flag workarounds.
- coro/test/CMakeLists.txt: Removed conditional compilation flags related to Clang-15.


