### PR TITLE
add compile option for msvc

### DIFF
--- a/async_simple/coro/test/CMakeLists.txt
+++ b/async_simple/coro/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 file(GLOB coro_test_src "*.cpp")
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/bigobj>")
 add_executable(async_simple_coro_test ${coro_test_src} ${PROJECT_SOURCE_DIR}/async_simple/test/dotest.cpp)
 
 target_link_libraries(async_simple_coro_test async_simple ${deplibs} ${testdeplibs})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

add compile option for msvc to avoid compile error when add more test code:

https://github.com/alibaba/async_simple/actions/runs/8200305183/job/22426819820#step:4:304

## What is changing

## Example


