### PR TITLE
fix the bug that collectAny can not accept move_only functor as callback

### DIFF
--- a/.github/workflows/cmake_gcc.yml
+++ b/.github/workflows/cmake_gcc.yml
@@ -26,6 +26,7 @@ jobs:
     - name: deps
       run: |
            sudo apt install -y build-essential
+           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
            sudo apt install -y gcc-${{matrix.gcc_version}} g++-${{matrix.gcc_version}}
            sudo apt install libaio-dev libgtest-dev libgmock-dev -y
 

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -218,15 +218,16 @@ struct CollectAnyVariadicPairAwaiter {
                         lazy._coro.promise()._executor = executor;
                     }
 
-                    lazy.start([result, event, continuation,
-                                callback](auto&& res) mutable {
-                        auto count = event->downCount();
-                        if (count == std::tuple_size<InputType>() + 1) {
-                            callback(std::move(res));
-                            *result = I;
-                            continuation.resume();
-                        }
-                    });
+                    lazy.start(
+                        [result, event, continuation,
+                         callback = std::move(callback)](auto&& res) mutable {
+                            auto count = event->downCount();
+                            if (count == std::tuple_size<InputType>() + 1) {
+                                callback(std::move(res));
+                                *result = I;
+                                continuation.resume();
+                            }
+                        });
                 }(std::get<0>(std::get<I>(input)),
                   std::get<1>(std::get<I>(input))),
                 ...);

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -1115,11 +1115,16 @@ TEST_F(LazyTest, testCollectAnyWithCallbackVariadic) {
         co_return co_await collectAny(std::move(args)...);
     };
 
+    auto move_only_v = std::make_unique<int>(0);
+    auto move_only_cb = [mv = std::move(move_only_v)](Try<int> v) {
+        EXPECT_EQ(42, v.value());
+    };
+
     size_t index =
         syncAwait(collectAnyLazy(std::pair{test0(), [](auto val) {}}));
 
-    index = syncAwait(collectAnyLazy(
-        std::pair{test1(), [](auto val) { EXPECT_EQ(42, val.value()); }}));
+    index =
+        syncAwait(collectAnyLazy(std::pair{test1(), std::move(move_only_cb)}));
 
     index = syncAwait(collectAnyLazy(
         std::pair{test2(42), [](auto str) { EXPECT_EQ("42", str.value()); }}));


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example


