### PR TITLE
coro/Generator: correct Generator alias of std::generator 

### DIFF
--- a/async_simple/coro/Generator.h
+++ b/async_simple/coro/Generator.h
@@ -29,7 +29,7 @@
 namespace async_simple::coro {
 
 template <class Ref, class V = void, class Allocator = void>
-using Generator = std::generator<Ref, V, AlloAllocator>;
+using Generator = std::generator<Ref, V, Allocator>;
 
 }  // namespace async_simple::coro
 

--- a/async_simple/coro/Generator.h
+++ b/async_simple/coro/Generator.h
@@ -22,7 +22,7 @@
 #warning "Clang 15 is not supported for Generator due to some issues."
 #endif
 
-#if __has_include(<generator>)
+#if defined(__cpp_lib_generator) && __has_include(<generator>)
 
 #include <generator>
 


### PR DESCRIPTION
before this change, the build fails, because `AlloAllocator` is not defined when the standard library provides `std::generator`, and the tree is built with C++23.

in this change, we replace `AlloAllocator` with `Allocator`. and the tree builds fine.

also, we include `<generator>` only if `__cpp_lib_generator` is defined. as the existence of the header does not imply that we are building with C++23.