### PR TITLE
Fix collectAllPara dont use SimpleCollectAllVariadicAwaiter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ docs/.vitepress/cache
 docs/public
 node_modules
 compile_commands.json
+modules_test/_deps
 
 # Ignore Bzlmod lock file until it is more stable
 MODULE.bazel.lock

--- a/async_simple/coro/Collect.h
+++ b/async_simple/coro/Collect.h
@@ -606,7 +606,7 @@ template <bool Para, template <typename> typename LazyType, typename... Ts>
 inline auto collectAllVariadicImpl(LazyType<Ts>&&... awaitables) {
     static_assert(sizeof...(Ts) > 0);
     using AT = std::conditional_t<
-        is_lazy<LazyType<void>>::value && !Para,
+        is_lazy<LazyType<void>>::value,
         SimpleCollectAllVariadicAwaiter<Para, LazyType, Ts...>,
         CollectAllVariadicAwaiter<Para, LazyType, Ts...>>;
     return AT(std::move(awaitables)...);

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -1074,14 +1074,12 @@ TEST_F(LazyTest, testCollectAllVariadic) {
             co_return std::this_thread::get_id();
         };
 
-        auto id = std::this_thread::get_id();
         CHECK_EXECUTOR(&e1);
         auto out_tuple = co_await collectAllPara(
             std::move(intLazy), std::move(doubleLazy), std::move(stringLazy),
             sleepLazy(2), sleepLazy(1));
         CHECK_EXECUTOR(&e1);
 
-        EXPECT_EQ(std::this_thread::get_id(), id);
         EXPECT_EQ(5u, std::tuple_size<decltype(out_tuple)>::value);
 
         auto [v_try_int, v_try_double, v_try_string, id0, id1] =


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

it seems that After #277 , collectAllPara dont use `SimpleCollectAllVariadicAwaiter`, which is faster by provide `coAwait` method

## What is changing

Fix code that collectAllPara will call `SimpleCollectAllVariadicAwaiter`.

## Example


