### PR TITLE
Deprecated setEx, instead by start(cb, ex)

### DIFF
--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -518,9 +518,10 @@ public:
 
     using Base::start;
 
+    // Bind an executor and start coroutine without scheduling immediately.
     template <typename F>
-    void start(F&& callback,
-               Executor* executor) requires(std::is_invocable_v<F&&, Try<T>>) {
+    void directlyStart(F&& callback, Executor* executor) requires(
+        std::is_invocable_v<F&&, Try<T>>) {
         this->_coro.promise()._executor = executor;
         return start(std::forward<F>(callback));
     }

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -269,7 +269,7 @@ TEST_F(LazyTest, testStartWithExecutor) {
         co_return;
     };
     std::promise<void> f;
-    test().start([&f](auto&&) { f.set_value(); }, &_executor);
+    test().directlyStart([&f](auto&&) { f.set_value(); }, &_executor);
     f.get_future().wait();
 }
 

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -17,6 +17,7 @@
 #include <condition_variable>
 #include <exception>
 #include <functional>
+#include <future>
 #include <mutex>
 #include <thread>
 #include <type_traits>
@@ -24,8 +25,10 @@
 #include <iostream>
 
 #include <chrono>
+#include "async_simple/Executor.h"
 #include "async_simple/coro/Collect.h"
 #include "async_simple/coro/Lazy.h"
+#include "async_simple/coro/Sleep.h"
 #include "async_simple/coro/SyncAwait.h"
 #include "async_simple/coro/test/Time.h"
 #include "async_simple/executors/SimpleExecutor.h"
@@ -254,6 +257,20 @@ TEST_F(LazyTest, testSimpleAsync2) {
     };
     triggerValue(100);
     ASSERT_EQ(101, syncAwait(test(), &_executor));
+}
+
+TEST_F(LazyTest, testStartWithExecutor) {
+    auto test = [this]() -> Lazy<void> {
+        auto executor = co_await CurrentExecutor();
+        EXPECT_TRUE(executor == &_executor);
+        EXPECT_TRUE(executor->currentThreadInExecutor() == false);
+        co_await async_simple::coro::sleep(10ms);
+        CHECK_EXECUTOR(&_executor);
+        co_return;
+    };
+    std::promise<void> f;
+    test().start([&f](auto&&) { f.set_value(); }, &_executor);
+    f.get_future().wait();
 }
 
 TEST_F(LazyTest, testVia) {

--- a/async_simple/uthread/Await.h
+++ b/async_simple/uthread/Await.h
@@ -98,8 +98,7 @@ decltype(auto) await(Executor* ex, Fn&& fn, Args&&... args) requires
         co_return;
     };
     lazy(std::forward<Fn>(fn), std::forward<Args>(args)...)
-        .setEx(ex)
-        .start([](auto&&) {});
+        .start([](auto&&) {}, ex);
     return await(std::move(f));
 }
 

--- a/async_simple/uthread/Await.h
+++ b/async_simple/uthread/Await.h
@@ -98,7 +98,7 @@ decltype(auto) await(Executor* ex, Fn&& fn, Args&&... args) requires
         co_return;
     };
     lazy(std::forward<Fn>(fn), std::forward<Args>(args)...)
-        .start([](auto&&) {}, ex);
+        .directlyStart([](auto&&) {}, ex);
     return await(std::move(f));
 }
 

--- a/docs/docs.cn/Executor.md
+++ b/docs/docs.cn/Executor.md
@@ -4,14 +4,16 @@ Executor是调度协程的关键组件。绝大多数开源协程框架提供内
 
 ## 使用Executor
 
-让协程运行在指定的调度器中非常简单，只需要创建协程时传递Executor给协程即可。在Lazy中通过`via()/setEx()`可以传递Executor；在Uthread中设置`async()`的Executor参数传递。
+让协程运行在指定的调度器中非常简单，只需要创建协程时传递Executor给协程即可。在Lazy中通过`via()`可以传递Executor。或者可以在start()接口中传递executor实现惰性调度，也可以在Uthread中设置`async()`的Executor参数传递。
 
 ```cpp
 Executor e;
 
 // lazy
-co_await f().via(&e).start([](){});
-co_await f().setEx(&e);
+// 协程绑定在对应的调度器上，立即调度执行
+f().via(&e).start([](auto&&){});
+// 协程绑定在对应的调度器上，延迟调度执行
+f().start([](auto&&){},&e);
 
 // uthread
 uthread::async<uthread::Launch::Schedule>(<lambda>, &e);

--- a/docs/docs.cn/Executor.md
+++ b/docs/docs.cn/Executor.md
@@ -4,7 +4,7 @@ Executor是调度协程的关键组件。绝大多数开源协程框架提供内
 
 ## 使用Executor
 
-让协程运行在指定的调度器中非常简单，只需要创建协程时传递Executor给协程即可。在Lazy中通过`via()`可以传递Executor。或者可以在start()接口中传递executor实现惰性调度，也可以在Uthread中设置`async()`的Executor参数传递。
+让协程运行在指定的调度器中非常简单，只需要创建协程时传递Executor给协程即可。在Lazy中通过`via()`可以传递Executor。或者可以使用`directlyStart(callback, executor)`接口启动协程并惰性调度，也可以在Uthread中设置`async()`的Executor参数传递。
 
 ```cpp
 Executor e;

--- a/docs/docs.en/Executor.md
+++ b/docs/docs.en/Executor.md
@@ -4,7 +4,7 @@ Executor is the key component for shceduling coroutine. A lot of the open-source
 
 ### Use Executor
 
-It is easy to assign a coroutine instance to an executor. The user need to pass the executor to coroutine only. The users could assign an executor to a Lazy then schedule immediately by `via`. User could also use start(cb, executor) to assign an executor wihtout schedul immediately. They could use `async` to pass Executor to Uthread.
+It is easy to assign a coroutine instance to an executor. The user need to pass the executor to coroutine only. The users could assign an executor to a Lazy then schedule immediately by `via`. User could also use `directlyStart(callback, executor)` to assign an executor wihtout schedul immediately. They could use `async` to pass Executor to Uthread.
 
 ```cpp
 Executor e;

--- a/docs/docs.en/Executor.md
+++ b/docs/docs.en/Executor.md
@@ -4,14 +4,16 @@ Executor is the key component for shceduling coroutine. A lot of the open-source
 
 ### Use Executor
 
-It is easy to assign a coroutine instance to an executor. The user need to pass the executor to coroutine only. The users could assign an executor to a Lazy by `via/setEx`. They could use `async` to pass Executor to Uthread.
+It is easy to assign a coroutine instance to an executor. The user need to pass the executor to coroutine only. The users could assign an executor to a Lazy then schedule immediately by `via`. User could also use start(cb, executor) to assign an executor wihtout schedul immediately. They could use `async` to pass Executor to Uthread.
 
 ```cpp
 Executor e;
 
 // lazy
-co_await f().via(&e).start([](){});
-co_await f().setEx(&e);
+// schedule to executor immediately
+f().via(&e).start([](auto&&){});
+// binding executor but dont schedule immediately
+f().start([](auto&&){},&e);
 
 // uthread
 uthread::async<uthread::Launch::Schedule>(<lambda>, &e);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

deprecated `Lazy::setEx()` instead by Lazy::start(cb,ex), which is may not expected behavior.

## What is changing

1. deprecated `Lazy::setEx()`
2. add `Lazy::start(cb,ex)`, which will start a coroutine and binding it to a new executor without scheduling immediately.

## Example

