### PR TITLE
[breakchange] refact lazy local variable

### DIFF
--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -406,7 +406,6 @@ public:
     auto coAwaitTry() { return TryAwaiter(std::exchange(_coro, nullptr)); }
 
 protected:
-
     Handle _coro;
 
     template <class, typename OAlloc, bool Para>
@@ -504,6 +503,10 @@ protected:
 // If any awaitable wants to derive the executor instance from its caller, it
 // should implement `coAwait(Executor*)` member method. Then the caller would
 // pass its executor instance to the awaitable.
+
+template <typename T>
+concept isDerivedFromLazyLocal = std::is_base_of_v<LazyLocalBase, T>;
+
 template <typename T = void>
 class [[nodiscard]] CORO_ONLY_DESTROY_WHEN_DONE ELIDEABLE_AFTER_AWAIT Lazy
     : public detail::LazyBase<T, /*reschedule=*/false> {

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -505,7 +505,9 @@ protected:
 // pass its executor instance to the awaitable.
 
 template <typename T>
-concept isDerivedFromLazyLocal = std::is_base_of_v<LazyLocalBase, T>;
+concept isDerivedFromLazyLocal = std::is_base_of_v<LazyLocalBase, T> && requires (const T* base) {
+    std::is_same_v<decltype(T::classof(base)),bool>;
+};
 
 template <typename T = void>
 class [[nodiscard]] CORO_ONLY_DESTROY_WHEN_DONE ELIDEABLE_AFTER_AWAIT Lazy

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -20,6 +20,7 @@
 #include <cstddef>
 #include <cstdio>
 #include <exception>
+#include <memory>
 #include <variant>
 #include "async_simple/Common.h"
 #include "async_simple/Try.h"
@@ -135,8 +136,7 @@ public:
 
     template <typename T>
     auto await_transform(CurrentLazyLocals<T>) {
-        return ReadyAwaiter<T*>(_lazy_local ? _lazy_local->dynamicCast<T>()
-                                            : nullptr);
+        return ReadyAwaiter<T*>(dynamicCast<T>(_lazy_local));
     }
 
     auto await_transform(Yield) { return YieldAwaiter(_executor); }
@@ -316,6 +316,7 @@ public:
             if constexpr (std::is_base_of<LazyPromiseBase,
                                           PromiseType>::value) {
                 auto& local = this->_handle.promise()._lazy_local;
+                std::unique_ptr<LazyLocalBase> guard{local};
                 logicAssert(
                     local == nullptr,
                     "co_await Lazy{}.setCancellation(...) is not allowed");

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -363,9 +363,6 @@ public:
 
     ~LazyBase() {
         if (_coro) {
-            if (_coro.operator bool()) {
-                delete this->_coro.promise()._lazy_local;
-            }
             _coro.destroy();
             _coro = nullptr;
         }

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -16,13 +16,14 @@
 #ifndef ASYNC_SIMPLE_CORO_LAZY_H
 #define ASYNC_SIMPLE_CORO_LAZY_H
 
-#include <type_traits>
-#include <utility>
 #ifndef ASYNC_SIMPLE_USE_MODULES
+
 #include <cstddef>
 #include <cstdio>
 #include <exception>
 #include <memory>
+#include <type_traits>
+#include <utility>
 #include <variant>
 #include "async_simple/Common.h"
 #include "async_simple/Try.h"

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -579,21 +579,6 @@ public:
         return Lazy<T>(std::exchange(this->_coro, nullptr));
     }
 
-    template <typename LazyLocal, typename... Args>
-    Lazy<T> setLazyLocal(Args&&... args) && {
-        Base::template setLazyLocal<SimpleLazyLocal<LazyLocal>>(
-            std::forward<Args>(args)...);
-        return Lazy<T>(std::exchange(this->_coro, nullptr));
-    }
-
-    template <typename LocalType>
-    Lazy<T> setLazyLocal(LocalType&& local) && {
-        Base::template setLazyLocal<
-            SimpleLazyLocal<std::remove_reference_t<LocalType>>>(
-            std::forward<LocalType>(local));
-        return Lazy<T>(std::exchange(this->_coro, nullptr));
-    }
-
     using Base::start;
 
     // Bind an executor and start coroutine without scheduling immediately.
@@ -658,23 +643,6 @@ public:
     template <isDerivedFromLazyLocal LazyLocal, typename... Args>
     RescheduleLazy<T> setLazyLocal(Args&&... args) && {
         Base::template setLazyLocal<LazyLocal>(std::forward<Args>(args)...);
-        return RescheduleLazy<T>(std::exchange(this->_coro, nullptr));
-    }
-
-    // user can override LazyLocal derived class's new/delete operator for
-    // custom allocate
-    template <typename LazyLocal, typename... Args>
-    RescheduleLazy<T> setLazyLocal(Args&&... args) && {
-        Base::template setLazyLocal<SimpleLazyLocal<LazyLocal>>(
-            std::forward<Args>(args)...);
-        return RescheduleLazy<T>(std::exchange(this->_coro, nullptr));
-    }
-
-    template <typename LocalType>
-    RescheduleLazy<T> setLazyLocal(LocalType&& local) && {
-        Base::template setLazyLocal<
-            SimpleLazyLocal<std::remove_reference_t<LocalType>>>(
-            std::forward<LocalType>(local));
         return RescheduleLazy<T>(std::exchange(this->_coro, nullptr));
     }
 

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -54,8 +54,6 @@ struct Yield {};
 template <typename T = LazyLocalBase>
 struct CurrentLazyLocals {};
 
-struct CurrentLazyLocalsTypeInfo {};
-
 namespace detail {
 template <class, typename OAlloc, bool Para>
 struct CollectAllAwaiter;
@@ -135,14 +133,9 @@ public:
         return ReadyAwaiter<Executor*>(_executor);
     }
 
-    auto await_transform(CurrentLazyLocalsTypeInfo) {
-        return ReadyAwaiter<const std::type_info*>(
-            _lazy_local ? _lazy_local->type() : nullptr);
-    }
-
     template <typename T>
     auto await_transform(CurrentLazyLocals<T>) {
-        return ReadyAwaiter<T*>(_lazy_local ? _lazy_local->dyn_cast<T>()
+        return ReadyAwaiter<T*>(_lazy_local ? _lazy_local->dynamicCast<T>()
                                             : nullptr);
     }
 

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -76,8 +76,6 @@ struct CollectAnyVariadicPairAwaiter;
 
 namespace detail {
 
-template <typename T>
-concept isDerivedFromLazyLocal = std::is_base_of<LazyLocalBase, T>();
 class LazyPromiseBase : public PromiseAllocator<void, true> {
 public:
     // Resume the caller waiting to the current coroutine. Note that we need

--- a/async_simple/coro/Lazy.h
+++ b/async_simple/coro/Lazy.h
@@ -505,8 +505,9 @@ protected:
 // pass its executor instance to the awaitable.
 
 template <typename T>
-concept isDerivedFromLazyLocal = std::is_base_of_v<LazyLocalBase, T> && requires (const T* base) {
-    std::is_same_v<decltype(T::classof(base)),bool>;
+concept isDerivedFromLazyLocal = std::is_base_of_v<LazyLocalBase, T> &&
+    requires(const T* base) {
+    std::is_same_v<decltype(T::classof(base)), bool>;
 };
 
 template <typename T = void>

--- a/async_simple/coro/LazyLocalBase.h
+++ b/async_simple/coro/LazyLocalBase.h
@@ -23,11 +23,15 @@
 #endif  // ASYNC_SIMPLE_USE_MODULES
 namespace async_simple::coro {
 
+namespace detail {
+struct LazyLocalBaseTypeTag {};
+}  // namespace detail
 class LazyLocalBase {
 private:
     template <typename Derived>
     friend class LazyLocalBaseImpl;
-    LazyLocalBase(void* typeinfo) : _typeinfo(typeinfo){};
+    LazyLocalBase(detail::LazyLocalBaseTypeTag* typeinfo)
+        : _typeinfo(typeinfo){};
 
 public:
     LazyLocalBase(std::nullptr_t) : _typeinfo(nullptr){};
@@ -37,18 +41,17 @@ public:
     virtual ~LazyLocalBase(){};
 
 protected:
-    void* _typeinfo;
+    detail::LazyLocalBaseTypeTag* _typeinfo;
 };
 
 template <typename Derived>
 class LazyLocalBaseImpl : public LazyLocalBase {
 public:
-    LazyLocalBaseImpl() : LazyLocalBase((void*)&typeTag){};
+    LazyLocalBaseImpl() : LazyLocalBase(&typeTag){};
     static bool isMe(LazyLocalBase* p) { return p->_typeinfo == &typeTag; }
 
 private:
-    struct Unit {};
-    inline const static Unit typeTag{};
+    inline static detail::LazyLocalBaseTypeTag typeTag{};
 };
 
 template <typename T>

--- a/async_simple/coro/LazyLocalBase.h
+++ b/async_simple/coro/LazyLocalBase.h
@@ -43,36 +43,16 @@ protected:
 template <typename T>
 concept isDerivedFromLazyLocal = std::is_base_of_v<LazyLocalBase, T>;
 
-template <typename T>
-struct SimpleLazyLocal : public LazyLocalBase {
-    template <typename... Args>
-    SimpleLazyLocal(Args&&... args)
-        : LazyLocalBase(&typeTag), localValue(std::forward<Args>(args)...) {}
-    T localValue;
-    static bool classof(LazyLocalBase* base) noexcept {
-        return &typeTag == base->getTypeTag();
-    }
-
-private:
-    inline static char typeTag;
-};
-
-template <typename T>
+template <isDerivedFromLazyLocal T>
 T* dynamicCast(LazyLocalBase* base) noexcept {
     if (base == nullptr) {
         return nullptr;
     }
     if constexpr (std::is_same_v<LazyLocalBase, T>) {
         return base;
-    } else if constexpr (isDerivedFromLazyLocal<T>) {
+    } else {
         if (T::classof(base)) {
             return static_cast<T*>(base);
-        } else {
-            return nullptr;
-        }
-    } else {
-        if (SimpleLazyLocal<T>::classof(base)) {
-            return &static_cast<SimpleLazyLocal<T>*>(base)->localValue;
         } else {
             return nullptr;
         }

--- a/async_simple/coro/LazyLocalBase.h
+++ b/async_simple/coro/LazyLocalBase.h
@@ -16,12 +16,11 @@
 #ifndef ASYNC_SIMPLE_CORO_LAZYLOCALBASE_H
 #define ASYNC_SIMPLE_CORO_LAZYLOCALBASE_H
 
-
 #ifndef ASYNC_SIMPLE_USE_MODULES
+#include <cstdint>
 #include <type_traits>
 #include <typeinfo>
 #include <utility>
-#include <cstdint>
 #endif  // ASYNC_SIMPLE_USE_MODULES
 namespace async_simple::coro {
 
@@ -35,10 +34,6 @@ public:
     LazyLocalBase(std::nullptr_t) : _typeinfo(nullptr){};
     template <typename T>
     T* dyn_cast() noexcept;
-    template <>
-    LazyLocalBase* dyn_cast<LazyLocalBase>() noexcept {
-        return this;
-    }
     bool empty() const noexcept { return _typeinfo == nullptr; }
     virtual const std::type_info* type() { return nullptr; }
     virtual ~LazyLocalBase(){};
@@ -60,7 +55,7 @@ private:
 };
 
 template <typename T>
-concept isDerivedFromLazyLocal = std::is_base_of<LazyLocalBaseImpl<T>, T>();
+concept isDerivedFromLazyLocal = std::is_base_of_v<LazyLocalBaseImpl<T>, T>;
 
 template <typename T>
 struct SimpleLazyLocal : public LazyLocalBaseImpl<SimpleLazyLocal<T>> {
@@ -71,7 +66,10 @@ struct SimpleLazyLocal : public LazyLocalBaseImpl<SimpleLazyLocal<T>> {
 
 template <typename T>
 T* LazyLocalBase::dyn_cast() noexcept {
-    if constexpr (isDerivedFromLazyLocal<T>) {
+    if constexpr (std::is_same_v<LazyLocalBase, T>) {
+        return this;
+    }
+    else if constexpr (isDerivedFromLazyLocal<T>) {
         if (&T::typeTag == _typeinfo) {
             return static_cast<T*>(this);
         } else {

--- a/async_simple/coro/LazyLocalBase.h
+++ b/async_simple/coro/LazyLocalBase.h
@@ -26,35 +26,39 @@ namespace async_simple::coro {
 class LazyLocalBase;
 
 class LazyLocalBase {
+private:
+    template <typename T>
+    friend T* dynamicCast(LazyLocalBase* base) noexcept;
+
 protected:
     template <typename Derived>
     friend class LazyLocalBaseImpl;
     LazyLocalBase(char* typeinfo) : _typeinfo(typeinfo) {
         assert(typeinfo != nullptr);
     };
-
 public:
-    static bool classof(LazyLocalBase*) noexcept { return true; }
     const char* getTypeTag() const noexcept { return _typeinfo; }
     LazyLocalBase() : _typeinfo(nullptr) {}
     virtual ~LazyLocalBase(){};
-
 protected:
     char* _typeinfo;
 };
 
 template <typename T>
 concept isDerivedFromLazyLocal = std::is_base_of_v<LazyLocalBase, T>;
-
 template <isDerivedFromLazyLocal T>
 T* dynamicCast(LazyLocalBase* base) noexcept {
-    if (base == nullptr) {
-        return nullptr;
-    } else if (T::classof(base)) {
-        return static_cast<T*>(base);
+    assert(base != nullptr);
+    if constexpr (std::is_same_v<T, LazyLocalBase>) {
+        return base;
     } else {
-        return nullptr;
+        if (T::classof(base)) {
+            return static_cast<T*>(base);
+        } else {
+            return nullptr;
+        }
     }
-}
+
+}  // namespace async_simple::coro
 }  // namespace async_simple::coro
 #endif

--- a/async_simple/coro/LazyLocalBase.h
+++ b/async_simple/coro/LazyLocalBase.h
@@ -68,8 +68,7 @@ template <typename T>
 T* LazyLocalBase::dynamicCast() noexcept {
     if constexpr (std::is_same_v<LazyLocalBase, T>) {
         return this;
-    }
-    else if constexpr (isDerivedFromLazyLocal<T>) {
+    } else if constexpr (isDerivedFromLazyLocal<T>) {
         if (T::isMe(this)) {
             return static_cast<T*>(this);
         } else {

--- a/async_simple/coro/LazyLocalBase.h
+++ b/async_simple/coro/LazyLocalBase.h
@@ -36,17 +36,17 @@ protected:
     LazyLocalBase(char* typeinfo) : _typeinfo(typeinfo) {
         assert(typeinfo != nullptr);
     };
+
 public:
     const char* getTypeTag() const noexcept { return _typeinfo; }
     LazyLocalBase() : _typeinfo(nullptr) {}
     virtual ~LazyLocalBase(){};
+
 protected:
     char* _typeinfo;
 };
 
 template <typename T>
-concept isDerivedFromLazyLocal = std::is_base_of_v<LazyLocalBase, T>;
-template <isDerivedFromLazyLocal T>
 T* dynamicCast(LazyLocalBase* base) noexcept {
     assert(base != nullptr);
     if constexpr (std::is_same_v<T, LazyLocalBase>) {

--- a/async_simple/coro/LazyLocalBase.h
+++ b/async_simple/coro/LazyLocalBase.h
@@ -45,7 +45,6 @@ namespace async_simple::coro {
 
 // };
 class LazyLocalBase {
-
 protected:
     LazyLocalBase(char* typeinfo) : _typeinfo(typeinfo) {
         assert(typeinfo != nullptr);

--- a/async_simple/coro/LazyLocalBase.h
+++ b/async_simple/coro/LazyLocalBase.h
@@ -23,8 +23,26 @@
 #include <utility>
 #endif  // ASYNC_SIMPLE_USE_MODULES
 namespace async_simple::coro {
-class LazyLocalBase;
 
+// User can derived user-defined class from Lazy Local variable to implement
+// user-define lazy local value.
+
+// For example:
+// struct mylocal : public LazyLocalBase {
+
+//     inline static char tag; // support a not-null unique address for type
+//     checking
+//     // init LazyLocalBase by unique address
+//     mylocal(std::string sv) : LazyLocalBase(&tag), name(std::move(sv)) {}
+//     // derived class support implement T::classof(LazyLocalBase*), which
+//     check if this object is-a derived class of T static bool
+//     classof(LazyLocalBase*) {
+//         return base->getTypeTag() == &tag;
+//     }
+
+//     std::string name;
+
+// };
 class LazyLocalBase {
 private:
     template <typename T>

--- a/async_simple/coro/LazyLocalBase.h
+++ b/async_simple/coro/LazyLocalBase.h
@@ -25,7 +25,8 @@
 namespace async_simple::coro {
 
 // User can derived user-defined class from Lazy Local variable to implement
-// user-define lazy local value by implement static function T::classof(const LazyLocalBase*).
+// user-define lazy local value by implement static function T::classof(const
+// LazyLocalBase*).
 
 // For example:
 // struct mylocal : public LazyLocalBase {
@@ -85,6 +86,6 @@ T* dynamicCast(LazyLocalBase* base) noexcept {
         }
     }
 }
-  // namespace async_simple::coro
+// namespace async_simple::coro
 }  // namespace async_simple::coro
 #endif

--- a/async_simple/coro/LazyLocalBase.h
+++ b/async_simple/coro/LazyLocalBase.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024, Alibaba Group Holding Limited;
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef ASYNC_SIMPLE_CORO_LAZYLOCALBASE_H
+#define ASYNC_SIMPLE_CORO_LAZYLOCALBASE_H
+
+
+#ifndef ASYNC_SIMPLE_USE_MODULES
+#include <type_traits>
+#include <typeinfo>
+#include <utility>
+#include <cstdint>
+#endif  // ASYNC_SIMPLE_USE_MODULES
+namespace async_simple::coro {
+
+class LazyLocalBase {
+private:
+    template <typename Derived>
+    friend class LazyLocalBaseImpl;
+    LazyLocalBase(void* typeinfo) : _typeinfo(typeinfo){};
+
+public:
+    LazyLocalBase(std::nullptr_t) : _typeinfo(nullptr){};
+    template <typename T>
+    T* dyn_cast() noexcept;
+    template <>
+    LazyLocalBase* dyn_cast<LazyLocalBase>() noexcept {
+        return this;
+    }
+    bool empty() const noexcept { return _typeinfo == nullptr; }
+    virtual const std::type_info* type() { return nullptr; }
+    virtual ~LazyLocalBase(){};
+
+protected:
+    void* _typeinfo;
+};
+
+template <typename Derived>
+class LazyLocalBaseImpl : public LazyLocalBase {
+public:
+    LazyLocalBaseImpl() : LazyLocalBase((void*)&typeTag){};
+
+private:
+    struct Unit {};
+    friend class LazyLocalBase;
+    inline const static Unit typeTag{};
+    const std::type_info* type() noexcept override { return &typeid(Derived); }
+};
+
+template <typename T>
+concept isDerivedFromLazyLocal = std::is_base_of<LazyLocalBaseImpl<T>, T>();
+
+template <typename T>
+struct SimpleLazyLocal : public LazyLocalBaseImpl<SimpleLazyLocal<T>> {
+    template <typename... Args>
+    SimpleLazyLocal(Args&&... args) : localValue(std::forward<Args>(args)...) {}
+    T localValue;
+};
+
+template <typename T>
+T* LazyLocalBase::dyn_cast() noexcept {
+    if constexpr (isDerivedFromLazyLocal<T>) {
+        if (&T::typeTag == _typeinfo) {
+            return static_cast<T*>(this);
+        } else {
+            return nullptr;
+        }
+    } else {
+        if (&SimpleLazyLocal<T>::typeTag == _typeinfo) {
+            return &static_cast<SimpleLazyLocal<T>*>(this)->localValue;
+        } else {
+            return nullptr;
+        }
+    }
+}
+}  // namespace async_simple::coro
+#endif

--- a/async_simple/coro/test/LazyLocalTest.cpp
+++ b/async_simple/coro/test/LazyLocalTest.cpp
@@ -32,7 +32,7 @@ struct mylocal : public LazyLocalBase {
     mylocal(std::string sv) : LazyLocalBase(&tag), name(std::move(sv)) {}
     std::string& hello() { return name; }
     std::string name;
-    static bool classof(LazyLocalBase* base) {
+    static bool classof(const LazyLocalBase* base) {
         return base->getTypeTag() == &tag;
     }
     inline static char tag;
@@ -42,7 +42,7 @@ struct mylocal2 : public LazyLocalBase {
     mylocal2(std::string sv) : LazyLocalBase(&tag), name(std::move(sv)) {}
     std::string& hello() { return name; }
     std::string name;
-    static bool classof(LazyLocalBase* base) {
+    static bool classof(const LazyLocalBase* base) {
         return base->getTypeTag() == &tag;
     }
     inline static char tag;
@@ -53,7 +53,7 @@ struct mylocal3 : public LazyLocalBase {
     mylocal3(mylocal3&&) = delete;
     std::string& hello() { return name; }
     std::string name;
-    static bool classof(LazyLocalBase* base) {
+    static bool classof(const LazyLocalBase* base) {
         return base->getTypeTag() == &tag;
     }
     inline static char tag;

--- a/async_simple/coro/test/LazyLocalTest.cpp
+++ b/async_simple/coro/test/LazyLocalTest.cpp
@@ -46,6 +46,7 @@ struct mylocal2 : public LazyLocalBase {
     }
     inline static char tag;
 };
+using namespace std::literals;
 
 TEST(LazyLocalTest, testMyLazyLocal) {
     async_simple::executors::SimpleExecutor ex(2);
@@ -71,7 +72,7 @@ TEST(LazyLocalTest, testMyLazyLocal) {
     };
     std::promise<void> p;
     std::future<void> f = p.get_future();
-    task().setLazyLocal<mylocal>("Hello").start(
+    task().setLazyLocal<mylocal>("Hello"s).start(
         [p = std::move(p)](auto&&) mutable { p.set_value(); });
 }
 
@@ -84,7 +85,8 @@ TEST(LazyLocalTest, testSetLazyLocalTwice) {
     };
     bool has_error = false;
     try {
-        syncAwait(task().setLazyLocal<mylocal>("2").setLazyLocal<mylocal>("1"));
+        syncAwait(
+            task().setLazyLocal<mylocal>("2"s).setLazyLocal<mylocal>("1"s));
     } catch (...) {
         has_error = true;
     }
@@ -100,7 +102,7 @@ TEST(LazyLocalTest, testSetLazyLocalNested) {
 
         bool has_error = false;
         try {
-            co_await sub_task().setLazyLocal<mylocal>("2");
+            co_await sub_task().setLazyLocal<mylocal>("2"s);
         } catch (...) {
             has_error = true;
         }
@@ -108,12 +110,12 @@ TEST(LazyLocalTest, testSetLazyLocalNested) {
         co_return;
     };
 
-    syncAwait(task().setLazyLocal<mylocal>("1"));
+    syncAwait(task().setLazyLocal<mylocal>("1"s));
 }
 
 TEST(LazyLocalTest, testSetLazyLocalButDoNothing) {
     auto task = [&]() -> Lazy<void> { co_return; };
-    auto task2 = task().setLazyLocal<mylocal>("1");
+    auto task2 = task().setLazyLocal<mylocal>("1"s);
 }
 
 }  // namespace async_simple::coro

--- a/async_simple/coro/test/LazyLocalTest.cpp
+++ b/async_simple/coro/test/LazyLocalTest.cpp
@@ -111,4 +111,9 @@ TEST(LazyLocalTest, testSetLazyLocalNested) {
     syncAwait(task().setLazyLocal<mylocal>("1"));
 }
 
+TEST(LazyLocalTest, testSetLazyLocalButDoNothing) {
+    auto task = [&]() -> Lazy<void> { co_return; };
+    auto task2 = task().setLazyLocal<mylocal>("1");
+}
+
 }  // namespace async_simple::coro

--- a/async_simple/coro/test/LazyLocalTest.cpp
+++ b/async_simple/coro/test/LazyLocalTest.cpp
@@ -27,86 +27,18 @@
 
 namespace async_simple::coro {
 
-TEST(LazyLocalTest, testSimpleLazyLocalNoOwnership) {
-    int* i = new int(10);
-    async_simple::executors::SimpleExecutor ex(2);
-    auto sub_task = [&]() -> Lazy<> {
-        auto localbase = co_await CurrentLazyLocals{};
-        EXPECT_NE(localbase, nullptr);
-        EXPECT_NE(localbase->getTypeTag(), nullptr);
-
-        int** v = co_await CurrentLazyLocals<int*>{};
-        EXPECT_NE(v, nullptr);
-        EXPECT_EQ(*v, i);
-        EXPECT_EQ(**v, 20);
-        **v = 30;
-    };
-
-    auto task = [&]() -> Lazy<> {
-        void* v = co_await CurrentLazyLocals{};
-        EXPECT_NE(v, nullptr);
-        (*i) = 20;
-        co_await sub_task();
-        co_return;
-    };
-    syncAwait(task().via(&ex).setLazyLocal(i));
-    EXPECT_EQ(*i, 30);
-
-    std::condition_variable cv;
-    std::mutex mut;
-    bool done = false;
-    task().via(&ex).setLazyLocal(i).start([&](Try<void>) {
-        std::unique_lock<std::mutex> lock(mut);
-        EXPECT_EQ(*i, 30);
-        delete i;
-        i = nullptr;
-        done = true;
-        cv.notify_all();
-    });
-    std::unique_lock<std::mutex> lock(mut);
-    cv.wait(lock, [&]() -> bool { return done == true; });
-    EXPECT_EQ(i, nullptr);
-}
-
-TEST(LazyLocalTest, testSimpleLazyLocal) {
-    async_simple::executors::SimpleExecutor ex(2);
-    auto sub_task = [&]() -> Lazy<> {
-        auto localbase = co_await CurrentLazyLocals{};
-        EXPECT_NE(localbase, nullptr);
-        EXPECT_NE(localbase->getTypeTag(), nullptr);
-
-        std::string* v = co_await CurrentLazyLocals<std::string>{};
-        EXPECT_NE(v, nullptr);
-        EXPECT_EQ(*v, "20");
-        *v = "30";
-    };
-
-    auto task = [&]() -> Lazy<> {
-        auto* u = co_await CurrentLazyLocals<int>{};
-        EXPECT_EQ(u, nullptr);
-        std::string* v = co_await CurrentLazyLocals<std::string>{};
-        EXPECT_NE(v, nullptr);
-        EXPECT_EQ(*v, "10");
-        (*v) = "20";
-        co_await sub_task();
-        co_return;
-    };
-    std::promise<void> p;
-    std::future<void> f = p.get_future();
-    task()
-        .via(&ex)
-        .setLazyLocal(std::string{"10"})
-        .start([p = std::move(p)](auto&&, LazyLocalBase* local) mutable {
-            EXPECT_NE(local, nullptr);
-            EXPECT_NE(dynamicCast<std::string>(local), nullptr);
-            EXPECT_EQ(*dynamicCast<std::string>(local), "30");
-            p.set_value();
-        });
-    f.wait();
-}
-
 struct mylocal : public LazyLocalBase {
     mylocal(std::string sv) : LazyLocalBase(&tag), name(std::move(sv)) {}
+    std::string& hello() { return name; }
+    std::string name;
+    static bool classof(LazyLocalBase* base) {
+        return base->getTypeTag() == &tag;
+    }
+    inline static char tag;
+};
+
+struct mylocal2 : public LazyLocalBase {
+    mylocal2(std::string sv) : LazyLocalBase(&tag), name(std::move(sv)) {}
     std::string& hello() { return name; }
     std::string name;
     static bool classof(LazyLocalBase* base) {
@@ -128,7 +60,7 @@ TEST(LazyLocalTest, testMyLazyLocal) {
         v->hello() = "Hey";
     };
     auto task = [&]() -> Lazy<> {
-        auto* u = co_await CurrentLazyLocals<int>{};
+        auto* u = co_await CurrentLazyLocals<mylocal2>{};
         EXPECT_EQ(u, nullptr);
         auto* v = co_await CurrentLazyLocals<mylocal>{};
         EXPECT_NE(v, nullptr);
@@ -142,7 +74,7 @@ TEST(LazyLocalTest, testMyLazyLocal) {
     task().setLazyLocal<mylocal>("Hello").start(
         [p = std::move(p)](auto&&, LazyLocalBase* local) mutable {
             EXPECT_NE(local, nullptr);
-            EXPECT_EQ(dynamicCast<std::string>(local), nullptr);
+            EXPECT_EQ(dynamicCast<mylocal2>(local), nullptr);
             EXPECT_NE(dynamicCast<mylocal>(local), nullptr);
             EXPECT_EQ(dynamicCast<mylocal>(local)->hello(), "Hey");
             p.set_value();
@@ -152,24 +84,24 @@ TEST(LazyLocalTest, testMyLazyLocal) {
 
 TEST(LazyLocalTest, testSetLazyLocalTwice) {
     auto task = [&]() -> Lazy<> {
-        auto* v = co_await CurrentLazyLocals<int>{};
+        auto* v = co_await CurrentLazyLocals<mylocal>{};
         EXPECT_NE(v, nullptr);
-        EXPECT_EQ(*v, 1);
+        EXPECT_EQ(v->hello(), "1");
         co_return;
     };
-    syncAwait(task().setLazyLocal(2).setLazyLocal(1));
+    syncAwait(task().setLazyLocal<mylocal>("2").setLazyLocal<mylocal>("1"));
 }
 
 TEST(LazyLocalTest, testSetLazyLocalNested) {
     auto sub_task = [&]() -> Lazy<> { co_return; };
     auto task = [&]() -> Lazy<void> {
-        auto* v = co_await CurrentLazyLocals<int>{};
+        auto* v = co_await CurrentLazyLocals<mylocal>{};
         EXPECT_NE(v, nullptr);
-        EXPECT_EQ(*v, 2);
+        EXPECT_EQ(v->hello(), "1");
 
         bool has_error = false;
         try {
-            co_await sub_task().setLazyLocal(1);
+            co_await sub_task().setLazyLocal<mylocal>("2");
         } catch (...) {
             has_error = true;
         }
@@ -177,7 +109,7 @@ TEST(LazyLocalTest, testSetLazyLocalNested) {
         co_return;
     };
 
-    syncAwait(task().setLazyLocal(2));
+    syncAwait(task().setLazyLocal<mylocal>("1"));
 }
 
 }  // namespace async_simple::coro

--- a/async_simple/coro/test/LazyLocalTest.cpp
+++ b/async_simple/coro/test/LazyLocalTest.cpp
@@ -30,13 +30,10 @@ namespace async_simple::coro {
 TEST(LazyLocalTest, testSimpleLazyLocalNoOwnership) {
     int* i = new int(10);
     async_simple::executors::SimpleExecutor ex(2);
-    const auto& type_info = typeid(async_simple::coro::SimpleLazyLocal<int*>);
     auto sub_task = [&]() -> Lazy<> {
         auto localbase = co_await CurrentLazyLocals{};
         EXPECT_NE(localbase, nullptr);
         EXPECT_FALSE(localbase->empty());
-        EXPECT_NE(localbase->type(), nullptr);
-        EXPECT_EQ(*localbase->type(), type_info);
 
         int** v = co_await CurrentLazyLocals<int*>{};
         EXPECT_NE(v, nullptr);
@@ -46,9 +43,6 @@ TEST(LazyLocalTest, testSimpleLazyLocalNoOwnership) {
     };
 
     auto task = [&]() -> Lazy<> {
-        auto&& info = co_await CurrentLazyLocalsTypeInfo{};
-        EXPECT_NE(info, nullptr);
-        EXPECT_TRUE(*info == type_info);
         void* v = co_await CurrentLazyLocals{};
         EXPECT_NE(v, nullptr);
         (*i) = 20;
@@ -76,14 +70,10 @@ TEST(LazyLocalTest, testSimpleLazyLocalNoOwnership) {
 
 TEST(LazyLocalTest, testSimpleLazyLocal) {
     async_simple::executors::SimpleExecutor ex(2);
-    const auto& type_info =
-        typeid(async_simple::coro::SimpleLazyLocal<std::string>);
     auto sub_task = [&]() -> Lazy<> {
         auto localbase = co_await CurrentLazyLocals{};
         EXPECT_NE(localbase, nullptr);
         EXPECT_FALSE(localbase->empty());
-        EXPECT_NE(localbase->type(), nullptr);
-        EXPECT_EQ(*localbase->type(), type_info);
 
         std::string* v = co_await CurrentLazyLocals<std::string>{};
         EXPECT_NE(v, nullptr);
@@ -92,9 +82,6 @@ TEST(LazyLocalTest, testSimpleLazyLocal) {
     };
 
     auto task = [&]() -> Lazy<> {
-        auto&& info = co_await CurrentLazyLocalsTypeInfo{};
-        EXPECT_NE(info, nullptr);
-        EXPECT_TRUE(*info == type_info);
         auto* u = co_await CurrentLazyLocals<int>{};
         EXPECT_EQ(u, nullptr);
         std::string* v = co_await CurrentLazyLocals<std::string>{};
@@ -111,8 +98,8 @@ TEST(LazyLocalTest, testSimpleLazyLocal) {
         .setLazyLocal(std::string{"10"})
         .start([p = std::move(p)](auto&&, LazyLocalBase* local) mutable {
             EXPECT_NE(local, nullptr);
-            EXPECT_NE(local->dyn_cast<std::string>(), nullptr);
-            EXPECT_EQ(*local->dyn_cast<std::string>(), "30");
+            EXPECT_NE(local->dynamicCast<std::string>(), nullptr);
+            EXPECT_EQ(*local->dynamicCast<std::string>(), "30");
             p.set_value();
         });
     f.wait();
@@ -125,14 +112,11 @@ struct mylocal : public LazyLocalBaseImpl<mylocal> {
 };
 
 TEST(LazyLocalTest, testMyLazyLocal) {
-    const auto& type_info = typeid(mylocal);
     async_simple::executors::SimpleExecutor ex(2);
     auto sub_task = [&]() -> Lazy<> {
         auto localbase = co_await CurrentLazyLocals{};
         EXPECT_NE(localbase, nullptr);
         EXPECT_FALSE(localbase->empty());
-        EXPECT_NE(localbase->type(), nullptr);
-        EXPECT_EQ(*localbase->type(), type_info);
 
         auto* v = co_await CurrentLazyLocals<mylocal>{};
         EXPECT_NE(v, nullptr);
@@ -140,9 +124,6 @@ TEST(LazyLocalTest, testMyLazyLocal) {
         v->hello() = "Hey";
     };
     auto task = [&]() -> Lazy<> {
-        auto&& info = co_await CurrentLazyLocalsTypeInfo{};
-        EXPECT_NE(info, nullptr);
-        EXPECT_TRUE(*info == type_info);
         auto* u = co_await CurrentLazyLocals<int>{};
         EXPECT_EQ(u, nullptr);
         auto* v = co_await CurrentLazyLocals<mylocal>{};
@@ -157,9 +138,9 @@ TEST(LazyLocalTest, testMyLazyLocal) {
     task().setLazyLocal<mylocal>("Hello").start(
         [p = std::move(p)](auto&&, LazyLocalBase* local) mutable {
             EXPECT_NE(local, nullptr);
-            EXPECT_EQ(local->dyn_cast<std::string>(), nullptr);
-            EXPECT_NE(local->dyn_cast<mylocal>(), nullptr);
-            EXPECT_EQ(local->dyn_cast<mylocal>()->hello(), "Hey");
+            EXPECT_EQ(local->dynamicCast<std::string>(), nullptr);
+            EXPECT_NE(local->dynamicCast<mylocal>(), nullptr);
+            EXPECT_EQ(local->dynamicCast<mylocal>()->hello(), "Hey");
             p.set_value();
         });
     f.wait();

--- a/docs/docs.cn/Lazy.md
+++ b/docs/docs.cn/Lazy.md
@@ -276,14 +276,14 @@ void func(int x, Executor *e) {
 
 # LazyLocals
 
-LazyLocals类似于线程环境下的thread_local。用户可以通过派生LazyLocals来自定义自己的LazyLocals。
+LazyLocals类似于线程环境下的thread_local。用户可以通过派生LazyLocals并实现静态函数`T::classof(const LazyLocalBase*)`来自定义LazyLocals。
 async_simple为LazyLocals提供了不依赖rtti且安全高效的类型转换检查，只需要做一次整数比较操作即可。此外，async_simple还会自动管理LazyLocal的生命周期。以下为使用示例：
 ```cpp
 template<typename T>
 struct mylocal: public LazyLocalBase {
     template<typename ...Args>
     mylocalImpl(Args...&& args): LazyLocalBase(&tag),value(std::forward<Args>(args)...){}
-    static bool classof(LazyLocalBase* base) {
+    static bool classof(const LazyLocalBase* base) {
         return base->getTypeTag() == &tag;
     }
     T value;

--- a/docs/docs.en/Lazy.md
+++ b/docs/docs.en/Lazy.md
@@ -274,7 +274,7 @@ So we could assign the executor at the root the task chain simply.
 
 # LazyLocals
 
-LazyLocals is similar to `thread_local` in a thread environment. Users can customize their own LazyLocals by deriving from LazyLocals. 
+LazyLocals is similar to `thread_local` in a thread environment. Users can customize their own LazyLocals by deriving from LazyLocals and implement static function `T::classsof(const LazyLocalBase*)` 
 
 `async_simple` provides a type conversion check for LazyLocals that is safe and efficient without relying on RTTI, requiring only a single integer comparison operation. Additionally, `async_simple` automatically manages the lifecycle of LazyLocal. Below is an example of usage:
 
@@ -283,7 +283,7 @@ template<typename T>
 struct mylocal: public LazyLocalBase {
     template<typename... Args>
     mylocalImpl(Args...&& args): LazyLocalBase(&tag), value(std::forward<Args>(args)...){}
-    static bool classof(LazyLocalBase* base) {
+    static bool classof(const LazyLocalBase* base) {
         return base->getTypeTag() == &tag;
     }
     T value;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Now, the lazy local is a void*, which is dangerous, and user need manage life-time manually.

## What is changing

Refact lazy local. Now we allow user add local variable derived from `LazyLocalBaseImpl`. we aslo support `SimpleLazyLocal` for simple local variable case.


## Example

```cpp

struct mylocal : public LazyLocalBaseImpl<mylocal> {
    mylocal(std::string name) : _name(std::move(name)) {}
    std::string& name() { return _name; }
    std::string _name;
};

Lazy<void> task() {
  // if no local or local type is not corret, return nullptr
  mylocal* local =co_await CurrentLazyLocals<mylocal>{};
  assert(base->name()=="Hello");
  local->name()="HI";

  // if no local variable, return nullptr
  LazyLocalBase* local =co_await CurrentLazyLocals{};
  assert(local->empty()==false);
}
// local-variable will life until callback finished. User dont need to manage it.
task().setLazyLocal<mylocal>("Hello"s).start([](auto&&){
});
```

The type check is very fast (only need compare a pointer). Dont need RTTI.



