### PR TITLE
fix collect heap-use-after-free

### DIFF
--- a/async_simple/Signal.h
+++ b/async_simple/Signal.h
@@ -24,11 +24,11 @@
 #include <bit>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <system_error>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
-#include <string>
 
 #include "async_simple/Common.h"
 #include "util/move_only_function.h"

--- a/async_simple/Signal.h
+++ b/async_simple/Signal.h
@@ -28,6 +28,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <string>
 
 #include "async_simple/Common.h"
 #include "util/move_only_function.h"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

The prev pull requests #402 may cause heap-use-after-free due to some error operation in collectAny

## What is changing

Fix bug by move variable into await_suspend() function's stack local variable

## Example


