### PR TITLE
add assert and [[nodiscard]] for spinlock

### DIFF
--- a/async_simple/coro/Mutex.h
+++ b/async_simple/coro/Mutex.h
@@ -25,6 +25,7 @@
 
 #ifndef ASYNC_SIMPLE_USE_MODULES
 #include <atomic>
+#include <cassert>
 #include <mutex>
 #include "async_simple/experimental/coroutine.h"
 

--- a/async_simple/coro/SpinLock.h
+++ b/async_simple/coro/SpinLock.h
@@ -16,8 +16,8 @@
 #ifndef ASYNC_SIMPLE_CORO_SPIN_LOCK_H
 #define ASYNC_SIMPLE_CORO_SPIN_LOCK_H
 
-#include <atomic>
 #ifndef ASYNC_SIMPLE_USE_MODULES
+#include <atomic>
 #include <cassert>
 #include <mutex>
 #include <thread>

--- a/async_simple/coro/SpinLock.h
+++ b/async_simple/coro/SpinLock.h
@@ -16,7 +16,9 @@
 #ifndef ASYNC_SIMPLE_CORO_SPIN_LOCK_H
 #define ASYNC_SIMPLE_CORO_SPIN_LOCK_H
 
+#include <atomic>
 #ifndef ASYNC_SIMPLE_USE_MODULES
+#include <cassert>
 #include <mutex>
 #include <thread>
 #include "async_simple/coro/Lazy.h"
@@ -60,9 +62,12 @@ public:
         }
     }
 
-    void unlock() noexcept { _locked.store(false, std::memory_order_release); }
+    void unlock() noexcept {
+        assert(_locked.load(std::memory_order_acquire) == true);
+        _locked.store(false, std::memory_order_release);
+    }
 
-    Lazy<std::unique_lock<SpinLock>> coScopedLock() {
+    [[nodiscard]] Lazy<std::unique_lock<SpinLock>> coScopedLock() {
         co_await coLock();
         co_return std::unique_lock<SpinLock>{*this, std::adopt_lock};
     }

--- a/async_simple/coro/test/SleepTest.cpp
+++ b/async_simple/coro/test/SleepTest.cpp
@@ -130,7 +130,7 @@ Lazy<void> cancelSleep() {
     auto sleep = [](int i, std::atomic<int>& cnt) -> Lazy<void> {
         bool cancel_flag = false;
         try {
-            co_await async_simple::coro::sleep(i * 1s);
+            co_await async_simple::coro::sleep(i * 2s);
         } catch (const async_simple::SignalException& err) {
             ++cnt;
             cancel_flag = true;
@@ -156,7 +156,7 @@ Lazy<void> cancelSleep() {
         auto tp2 = std::chrono::steady_clock::now();
         EXPECT_EQ(cnt, 99);
         std::cout << "cost time: " << (tp2 - tp1) / 1ms << "ms" << std::endl;
-        EXPECT_LE((tp2 - tp1) / 1ms, 800);
+        EXPECT_LE((tp2 - tp1) / 1ms, 1800);
     }
     {
         std::vector<RescheduleLazy<void>> works;
@@ -169,7 +169,7 @@ Lazy<void> cancelSleep() {
         auto tp2 = std::chrono::steady_clock::now();
         EXPECT_EQ(cnt, 99);
         std::cout << "cost time: " << (tp2 - tp1) / 1ms << "ms" << std::endl;
-        EXPECT_LE((tp2 - tp1) / 1ms, 800);
+        EXPECT_LE((tp2 - tp1) / 1ms, 1800);
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

1. Close #391 
2. We found some mistake use of spinlock in [user issue](https://github.com/alibaba/yalantinglibs/issues/881)

## What is changing

1. add cassert header for `Mutex.h`
3. add nodiscard attribute for `SpinLock::coScopedLock()`
4. add assert for `SpinLock::unlock()`

## Example


