### PR TITLE
fix signal dont triggered bug in collectAll & slot::emplace()

### DIFF
--- a/async_simple/Signal.h
+++ b/async_simple/Signal.h
@@ -205,14 +205,17 @@ public:
                       "we dont allow emplace an empty signal handler");
         logicAssert(std::popcount(static_cast<uint64_t>(type)) == 1,
                     "It's not allow to emplace for multiple signals");
-        // trigger-once signal has already been triggered
+        auto handler = std::make_unique<detail::SignalSlotSharedState::Handler>(
+            std::forward<Args>(args)...);
+        auto oldHandlerPtr = loadHandler<true>(type);
+        // check trigger-once signal has already been triggered
+        // if signal has already been triggered, return false
         if (!detail::SignalSlotSharedState::isMultiTriggerSignal(type) &&
             (signal()->state() & type)) {
             return false;
         }
-        auto handler = std::make_unique<detail::SignalSlotSharedState::Handler>(
-            std::forward<Args>(args)...);
-        auto oldHandlerPtr = loadHandler<true>(type);
+        // if signal triggered later, we will found it by atomic handler CAS
+        // failed.
         auto oldHandler = oldHandlerPtr->load(std::memory_order_acquire);
         if (oldHandler ==
             &detail::SignalSlotSharedState::HandlerManager::emittedTag) {

--- a/async_simple/coro/CountEvent.h
+++ b/async_simple/coro/CountEvent.h
@@ -34,7 +34,7 @@ namespace detail {
 // The last 'down' will resume the awaiting coroutine on this event.
 class CountEvent {
 public:
-    CountEvent(size_t count) : _count(count + 1) {}
+    CountEvent(size_t count) : _count(count) {}
     CountEvent(const CountEvent&) = delete;
     CountEvent(CountEvent&& other)
         : _count(other._count.exchange(0, std::memory_order_relaxed)),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

### `slot::emplace()`

When we call `slot::emplace()`, we check signal state before construct handler. however, when `signal::emit()` called, it will set signal state then set the construct handler.

A possible order:
1. Thread A: `slot::emplace()` check signal state, no triggered now.
2. Thread A: `slot::emplace()` construct signal handler.
3. Thread B: `signal::emit()` set signal state
4. Thread B: `signal::emit()` load signal handler and found it's `nullptr`, emit over
5. Thread A `slot::emplace()` set the signal handler by CAS successful. return true.

Now, `slot::emplace()` will return true and signal handler won't be executed. the signal is loss.

### `collectAny`

`collectAny` should emit signal when the first handler resume, but now it may won't emit it if `downCount` was called in `await_suspend`


## What is changing

### `slot::emplace()`

`slot::emplace()` will construct signal handler before check signal state. 

Because `signal::emit()` will always set state before load signal handler. so if `signal::emit()` load signal handler result is `nullptr`, `slot::emplace()` will always get the signal by check state.

### collectAll and collectAny

Remove `downCount` call in `await_suspend`

## Example


