### PR TITLE
1. 修复LazyTest::testYield测试用例

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         /Zc:__cplusplus
         /await:strict
         /EHa
+        /bigobj
+        /utf-8
         )
 else()
     set(CXX_FLAGS

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -303,43 +303,30 @@ TEST_F(LazyTest, testYield) {
     executors::SimpleExecutor executor(1);
     std::mutex m1;
     std::mutex m2;
-    int value1 = 0;
-    int value2 = 0;
+    std::atomic<int> value = 0;
     m1.lock();
     m2.lock();
 
-    auto test1 = [](std::mutex& m, int& value) -> Lazy<void> {
+    auto test1 = [&value](std::mutex& m) -> Lazy<void> {
         m.lock();
         // push task to queue's tail
         co_await Yield();
+        EXPECT_EQ(value, 1);
         value++;
+        m.unlock();
         co_return;
     };
 
-    auto test2 = [](std::mutex& m, int& value) -> Lazy<void> {
+    auto test2 = [&value](std::mutex& m) -> Lazy<void> {
         m.lock();
+        EXPECT_EQ(value, 0);
         value++;
+        m.unlock();
         co_return;
     };
 
-    test1(m1, value1).via(&executor).start([](Try<void> result) {});
-    std::this_thread::sleep_for(100000us);
-    ASSERT_EQ(0, value1);
-
-    test2(m2, value2).via(&executor).start([](Try<void> result) {});
-    std::this_thread::sleep_for(100000us);
-    ASSERT_EQ(0, value2);
-
-    m1.unlock();
-    std::this_thread::sleep_for(100000us);
-    ASSERT_EQ(0, value1);
-    ASSERT_EQ(0, value2);
-
-    m2.unlock();
-    std::this_thread::sleep_for(100000us);
-    ASSERT_EQ(1, value1);
-    ASSERT_EQ(1, value2);
-
+    test1(m1).via(&executor).start([](Try<void> result) {});
+    test2(m2).via(&executor).start([](Try<void> result) {});
     m1.unlock();
     m2.unlock();
 }

--- a/cmake/FindGTest.cmake
+++ b/cmake/FindGTest.cmake
@@ -10,7 +10,7 @@ else()
     FetchContent_Declare(
         googletest
         GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG release-1.11.0
+        GIT_TAG release-1.12.1
         GIT_SHALLOW ON
     )
     


### PR DESCRIPTION
# 修复与改进说明

## 修复测试错误

- **文件位置**: `LazyTest.cpp:285`
- **测试用例**: `TEST_F(LazyTest, testYield)`
- **错误信息**: `D:\a_work\1\s\src\vctools\crt\github\stl\src\mutex.cpp(166): unlock of unowned mutex`

- **原因分析**:
锁的加锁与解锁操作发生在不同线程，导致 `unlock` 操作作用于非当前线程持有的互斥量。
- 参考资料: [cppreference - std::mutex::unlock](https://en.cppreference.com/w/cpp/thread/mutex/unlock)
- **解决方法**:
确保加锁与解锁操作在同一线程中执行。

## 升级 Googletest 版本

- **解决编译错误**:
Compatibility with CMake < 3.5 has been removed from CMake.
- **通过升级 Googletest，确保与现代 CMake 版本兼容**。

## MSVC 编译器选项优化

- **添加 `/bigobj` 选项**，解除单个 .obj 文件大小限制（测试目标文件过大）。
- **添加 `/utf-8` 选项**，确保源文件统一使用 UTF-8 编码，避免字符集问题。