### PR TITLE
fix(NFC): bazel build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
 
 uthread_prefix = "async_simple/uthread/internal/"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,15 +1,19 @@
 module(name = "com_github_async_simple")
-bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest", dev_dependency = True)
-bazel_dep(name = "google_benchmark", version = "1.8.5", repo_name = "com_google_benchmark", dev_dependency = True)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True, repo_name = "com_google_googletest")
+bazel_dep(name = "google_benchmark", version = "1.9.5", dev_dependency = True, repo_name = "com_google_benchmark")
 bazel_dep(name = "boringssl", version = "0.20250311.0", dev_dependency = True)
+
+bazel_dep(name = "rules_cc", version = "0.2.16")
 
 # Hedron's Compile Commands Extractor for Bazel
 # https://github.com/hedronvision/bazel-compile-commands-extractor
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
 git_override(
     module_name = "hedron_compile_commands",
-    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
     commit = "1e08f8e0507b6b6b1f4416a9a22cf5c28beaba93",
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
 )

--- a/async_simple/coro/test/BUILD.bazel
+++ b/async_simple/coro/test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
 
 cc_library(
@@ -9,14 +10,14 @@ cc_library(
 cc_test(
     name = "async_simple_coro_test",
     srcs = glob(["*.cpp"]),
-    deps = [
-        "//:async_simple",
-        "//async_simple/test:gtest_main",
-        ":hdrs_dep",
-    ],  
     copts = ASYNC_SIMPLE_COPTS + select({
         "@platforms//os:windows": [],
         # Clang gives incorrect warnings, See https://github.com/llvm/llvm-project/issues/56768
         "//conditions:default": ["-Wno-unsequenced"],
-    })
+    }),
+    deps = [
+        ":hdrs_dep",
+        "//:async_simple",
+        "//async_simple/test:gtest_main",
+    ],
 )

--- a/async_simple/coro/test/GeneratorTest.cpp
+++ b/async_simple/coro/test/GeneratorTest.cpp
@@ -228,7 +228,7 @@ public:
 
 TEST_F(GeneratorTest, testIterator) {
     size_t n = 15;
-    for (int j = 0; int i : fibonacci_sequence(n)) {
+    for (int j = 0; auto i : fibonacci_sequence(n)) {
         EXPECT_EQ(i, fibonacci_expected[j++]);
     }
 }

--- a/async_simple/coro/test/LazyTest.cpp
+++ b/async_simple/coro/test/LazyTest.cpp
@@ -1438,7 +1438,7 @@ TEST_F(LazyTest, testCollectAnyVariadicWithCancel) {
             collectAny<SignalType::Terminate>(
                 my_sleep(10ms, SignalType::Terminate, false),
                 my_sleep(5s, SignalType::Terminate, true, false)));
-        EXPECT_EQ(result.index(), 1);
+        EXPECT_EQ(result.index(), 1u);
         auto slot2 = co_await CurrentSlot{};
         EXPECT_EQ(slot, slot2);
     }()
@@ -1454,7 +1454,7 @@ TEST_F(LazyTest, testCollectAnyVariadicWithCancel) {
             collectAny<SignalType::None>(
                 my_sleep(10ms, SignalType::None, false),
                 my_sleep(200ms, SignalType::None, false)));
-        EXPECT_EQ(result.index(), 1);
+        EXPECT_EQ(result.index(), 1u);
         auto slot2 = co_await CurrentSlot{};
         EXPECT_EQ(slot, slot2);
     }()
@@ -1468,7 +1468,7 @@ TEST_F(LazyTest, testCollectAnyVariadicWithCancel) {
             collectAny<SignalType::None>(
                 my_sleep(10ms, SignalType::None, false),
                 my_sleep(200ms, SignalType::Terminate)));
-        EXPECT_EQ(result.index(), 1);
+        EXPECT_EQ(result.index(), 1u);
         auto slot2 = co_await CurrentSlot{};
         EXPECT_EQ(slot, slot2);
     }()
@@ -1491,7 +1491,7 @@ TEST_F(LazyTest, testCollectAnyWithCancel) {
         v3.push_back(collectAny<SignalType::Terminate>(std::move(v1)));
         v3.push_back(collectAny<SignalType::Terminate>(std::move(v2)));
         auto result = co_await collectAny<SignalType::All>(std::move(v3));
-        EXPECT_EQ(result.index(), 1);
+        EXPECT_EQ(result.index(), 1u);
         auto slot2 = co_await CurrentSlot{};
         EXPECT_EQ(slot, slot2);
     }()
@@ -1508,7 +1508,7 @@ TEST_F(LazyTest, testCollectAnyWithCancel) {
         v3.push_back(collectAny<SignalType::Terminate>(std::move(v1)));
         v3.push_back(collectAny<SignalType::None>(std::move(v2)));
         auto result = co_await collectAny<SignalType::None>(std::move(v3));
-        EXPECT_EQ(result.index(), 1);
+        EXPECT_EQ(result.index(), 1u);
         auto slot2 = co_await CurrentSlot{};
         EXPECT_EQ(slot, slot2);
     }()
@@ -1525,7 +1525,7 @@ TEST_F(LazyTest, testCollectAnyWithCancel) {
         v3.push_back(collectAny<SignalType::Terminate>(std::move(v1)));
         v3.push_back(collectAny<SignalType::None>(std::move(v2)));
         auto result = co_await collectAny<SignalType::Terminate>(std::move(v3));
-        EXPECT_EQ(result.index(), 1);
+        EXPECT_EQ(result.index(), 1u);
         auto slot2 = co_await CurrentSlot{};
         EXPECT_EQ(slot, slot2);
     }()

--- a/async_simple/coro/test/ResumeByScheduleTest.cpp
+++ b/async_simple/coro/test/ResumeByScheduleTest.cpp
@@ -130,8 +130,8 @@ TEST(ResumeBySchedule, basic) {
     std::unique_lock guard(mut);
     cv.wait(guard, [&]() -> bool { return done_count == 100; });
     cbs.Stop();
-    EXPECT_EQ(ex.checkin_count_, 0);
-    EXPECT_LE(ex.schedule_count_, 200);
+    EXPECT_EQ(ex.checkin_count_, 0u);
+    EXPECT_LE(ex.schedule_count_, 200u);
 }
 
 }  // namespace coro

--- a/async_simple/executors/test/BUILD.bazel
+++ b/async_simple/executors/test/BUILD.bazel
@@ -1,11 +1,12 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
 
 cc_test(
     name = "async_simple_executor_test",
     srcs = glob(["*.cpp"]),
+    copts = ASYNC_SIMPLE_COPTS,
     deps = [
         "//:async_simple",
         "//async_simple/test:gtest_main",
-    ],  
-    copts = ASYNC_SIMPLE_COPTS,
+    ],
 )

--- a/async_simple/executors/test/SimpleExecutorTest.cpp
+++ b/async_simple/executors/test/SimpleExecutorTest.cpp
@@ -55,5 +55,5 @@ TEST(SimpleExecutorTest, testNormal) {
         async_simple::util::move_only_function(std::move(move_only_functor)));
     std::unique_lock<std::mutex> guard(mut);
     cv.wait(guard, [&]() { return done_count == 2; });
-    EXPECT_EQ(sum, 30);
+    EXPECT_EQ(sum, 30u);
 }

--- a/async_simple/test/BUILD.bazel
+++ b/async_simple/test/BUILD.bazel
@@ -1,23 +1,24 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
 
 cc_library(
     name = "gtest_main",
     srcs = ["dotest.cpp"],
     hdrs = ["unittest.h"],
-    deps = [
-        "//:simple_executors",
-        "@com_google_googletest//:gtest"
-    ],
     copts = ASYNC_SIMPLE_COPTS,
     visibility = ["//visibility:public"],
+    deps = [
+        "//:simple_executors",
+        "@com_google_googletest//:gtest",
+    ],
 )
 
 cc_test(
     name = "async_simple_test",
     srcs = glob(["*Test.cpp"]),
+    copts = ASYNC_SIMPLE_COPTS,
     deps = [
         "//:async_simple",
         "//async_simple/test:gtest_main",
     ],
-    copts = ASYNC_SIMPLE_COPTS,
 )

--- a/async_simple/test/CancellationTest.cpp
+++ b/async_simple/test/CancellationTest.cpp
@@ -466,7 +466,7 @@ TEST_F(CancellationTest, testDerivedSignal) {
         SignalType::Terminate, [](SignalType type, Signal* signal) {
             auto mySignal = dynamic_cast<MySignal*>(signal);
             EXPECT_NE(mySignal, nullptr);
-            EXPECT_EQ(mySignal->myState, 1);
+            EXPECT_EQ(mySignal->myState, 1u);
         });
     mySignal->myState = 1;
     mySignal->emits(SignalType::Terminate);

--- a/async_simple/uthread/test/BUILD.bazel
+++ b/async_simple/uthread/test/BUILD.bazel
@@ -1,14 +1,15 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
 
 cc_test(
     name = "async_simple_uthread_test",
     srcs = select({
-        "//bazel/config:async_simple_with_uthread" : glob(["*.cpp"]),
-        "//conditions:default" : [],
-    }), 
+        "//bazel/config:async_simple_with_uthread": glob(["*.cpp"]),
+        "//conditions:default": [],
+    }),
+    copts = ASYNC_SIMPLE_COPTS,
     deps = [
         "//:async_simple",
         "//async_simple/test:gtest_main",
     ],
-    copts = ASYNC_SIMPLE_COPTS,
 )

--- a/async_simple/uthread/test/UthreadAllocTest.cpp
+++ b/async_simple/uthread/test/UthreadAllocTest.cpp
@@ -110,7 +110,7 @@ TEST_F(UthreadAllocSwapTest, testSwitch) {
     while (running) {
     }
 
-    EXPECT_NE(get_stack_holder_count, 0);
+    EXPECT_NE(get_stack_holder_count, 0u);
     while (!delete_stack_holder_count) {
     }
 

--- a/async_simple/util/test/BUILD.bazel
+++ b/async_simple/util/test/BUILD.bazel
@@ -1,11 +1,12 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
 
 cc_test(
     name = "async_simple_util_test",
     srcs = glob(["*.cpp"]),
+    copts = ASYNC_SIMPLE_COPTS,
     deps = [
         "//:async_simple",
         "//async_simple/test:gtest_main",
     ],
-    copts = ASYNC_SIMPLE_COPTS,
 )

--- a/benchmarks/BUILD.bazel
+++ b/benchmarks/BUILD.bazel
@@ -1,37 +1,41 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
 
 cc_library(
     name = "benchmark_main",
     srcs = ["benchmark_main.cpp"],
-    hdrs = glob(["*.h", "*.hpp"]),
+    hdrs = glob([
+        "*.h",
+        "*.hpp",
+    ]),
+    copts = ASYNC_SIMPLE_COPTS,
+    defines = select({
+        "//bazel/config:async_simple_with_uthread": ["ASYNC_SIMPLE_BENCHMARK_UTHREAD"],
+        "//conditions:default": [],
+    }),
     deps = [
         "//:async_simple",
         "//:simple_executors",
         "@com_google_benchmark//:benchmark",
     ],
-    defines = select({
-        "//bazel/config:async_simple_with_uthread" : ["ASYNC_SIMPLE_BENCHMARK_UTHREAD"],
-        "//conditions:default" : [],
-    }),
-    copts = ASYNC_SIMPLE_COPTS,
 )
 
 cc_binary(
     name = "benchmarking",
     srcs = [
+        "CallDepth.bench.cpp",
+        "Future.bench.cpp",
+        "Lazy.bench.cpp",
+        "Mutex.bench.cpp",
         "PureSwitch.bench.cpp",
         "ReadFile.bench.cpp",
-        "CallDepth.bench.cpp",
-        "Lazy.bench.cpp",
-        "Future.bench.cpp",
-        "ThreadPool.bench.cpp",
-        "Mutex.bench.cpp",
+        "SharedMutex.bench.cpp",
         "SpinLock.bench.cpp",
-        "SharedMutex.bench.cpp"
+        "ThreadPool.bench.cpp",
     ] + select({
         "//bazel/config:async_simple_with_uthread": ["Uthread.bench.cpp"],
         "//conditions:default": [],
     }),
-    deps = [":benchmark_main"],
     copts = ASYNC_SIMPLE_COPTS,
+    deps = [":benchmark_main"],
 )

--- a/demo_example/BUILD.bazel
+++ b/demo_example/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel/config:copt.bzl", "ASYNC_SIMPLE_COPTS")
 
 cc_library(
@@ -6,8 +7,8 @@ cc_library(
         "asio/**/*.hpp",
         "asio/**/*.ipp",
     ]),
-    visibility = ["//visibility:public"],
     includes = ["asio"],
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
@@ -17,116 +18,115 @@ cc_library(
         "asio_util.hpp",
     ],
     deps = [
+        ":asio",
         "//:async_simple",
         "//:simple_executors",
-        ":asio",
     ],
 )
 
 cc_binary(
     name = "CountChar",
     srcs = ["CountChar.cpp"],
-    deps = ["//:async_simple"],
     copts = ASYNC_SIMPLE_COPTS,
+    deps = ["//:async_simple"],
 )
 
 cc_binary(
     name = "ReadFiles",
     srcs = ["ReadFiles.cpp"],
+    copts = ASYNC_SIMPLE_COPTS,
     deps = [
         "//:async_simple",
         "//:simple_executors",
     ],
-    copts = ASYNC_SIMPLE_COPTS,
 )
 
 cc_binary(
     name = "async_echo_server",
     srcs = ["async_echo_server.cpp"],
-    deps = [":hdrs_dep"],
     copts = ASYNC_SIMPLE_COPTS,
+    deps = [":hdrs_dep"],
 )
-
 
 cc_binary(
     name = "async_echo_client",
     srcs = ["async_echo_client.cpp"],
-    deps = [":hdrs_dep"],
     copts = ASYNC_SIMPLE_COPTS,
+    deps = [":hdrs_dep"],
 )
 
 cc_binary(
     name = "block_echo_server",
     srcs = ["block_echo_server.cpp"],
-    deps = [":hdrs_dep"],
     copts = ASYNC_SIMPLE_COPTS,
+    deps = [":hdrs_dep"],
 )
 
 cc_binary(
     name = "block_echo_client",
     srcs = ["block_echo_client.cpp"],
-    deps = [":hdrs_dep"],
     copts = ASYNC_SIMPLE_COPTS,
+    deps = [":hdrs_dep"],
 )
 
 cc_library(
     name = "http_hdrs_dep",
     hdrs = glob([
-    	"http/**/*.hpp",
+        "http/**/*.hpp",
         "io_context_pool.hpp",
     ]),
-    deps = [":hdrs_dep"],
     visibility = ["//visibility:public"],
+    deps = [":hdrs_dep"],
 )
 
 cc_binary(
     name = "http_server",
     srcs = ["http/coroutine_http/http_server.cpp"],
-    deps = [":http_hdrs_dep"],
     copts = ASYNC_SIMPLE_COPTS,
+    deps = [":http_hdrs_dep"],
 )
 
 cc_binary(
     name = "multiple_core_http_server",
     srcs = ["http/coroutine_http/multiple_core_http_server.cpp"],
-    deps = [":http_hdrs_dep"],
     copts = ASYNC_SIMPLE_COPTS,
+    deps = [":http_hdrs_dep"],
 )
 
 cc_binary(
     name = "http_client",
     srcs = ["http/coroutine_http/http_client.cpp"],
-    deps = [":http_hdrs_dep"],
     copts = ASYNC_SIMPLE_COPTS,
+    deps = [":http_hdrs_dep"],
 )
 
 cc_binary(
     name = "block_http_server",
     srcs = ["http/block_http/block_http_server.cpp"],
-    deps = [":http_hdrs_dep"],
     copts = ASYNC_SIMPLE_COPTS,
+    deps = [":http_hdrs_dep"],
 )
 
 cc_binary(
     name = "smtp_client",
     srcs = ["smtp/smtp_client.cpp"],
-    deps = [":hdrs_dep"] + select({
-        "//bazel/config:async_simple_enable_ssl": [
-            "@boringssl//:ssl",
-            "@boringssl//:crypto",
-        ],
-        "//conditions:default" : [],
-    }),
     copts = ASYNC_SIMPLE_COPTS,
     defines = select({
         "//bazel/config:async_simple_enable_ssl": ["ENABLE_SSL"],
-        "//conditions:default" : [],
+        "//conditions:default": [],
+    }),
+    deps = [":hdrs_dep"] + select({
+        "//bazel/config:async_simple_enable_ssl": [
+            "@boringssl//:crypto",
+            "@boringssl//:ssl",
+        ],
+        "//conditions:default": [],
     }),
 )
 
 cc_binary(
     name = "pmr_lazy",
     srcs = ["pmr_lazy.cpp"],
-    deps = ["//:async_simple"],
     copts = ASYNC_SIMPLE_COPTS,
+    deps = ["//:async_simple"],
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Current bazel build not work out of the box.

## What is changing

1. in bazel 9, function like cc_test is not builtin, need to import from rules_cc.
2. the version bump in module.bazel is needed, some old version use old function parameter that does not exist in bazel 9.
3. the bazel format change is generated by buildifier.
4. the cpp file change is due to -Werror=sign-compare

