### PR TITLE
bazel: use libaio from bcr

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: deps
-      # Install Bazel See: https://bazel.build/install/ubuntu
-      run: |
-           sudo apt install -y libaio-dev
     - name: Build
       # Build your program with clang
       working-directory: ${{github.workspace}}

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -34,11 +34,11 @@ cc_library(
         "//bazel/config:async_simple_has_not_aio": ["ASYNC_SIMPLE_HAS_NOT_AIO"],
         "//conditions:default": [],
     }),
-    linkopts = select({
-        "//bazel/config:async_simple_has_not_aio": [],
-        "//conditions:default": ["-laio"],
-    }),
     visibility = ["//visibility:public"],
+    deps = select({
+        "//bazel/config:async_simple_has_not_aio": [],
+        "//conditions:default": ["@libaio//:aio"],
+    }),
 )
 
 cc_library(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,13 +1,13 @@
 module(name = "com_github_async_simple")
 
-bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "libaio", version = "0.3.113.bcr.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.16")
 
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True, repo_name = "com_google_googletest")
 bazel_dep(name = "google_benchmark", version = "1.9.5", dev_dependency = True, repo_name = "com_google_benchmark")
 bazel_dep(name = "boringssl", version = "0.20250311.0", dev_dependency = True)
-
-bazel_dep(name = "rules_cc", version = "0.2.16")
 
 # Hedron's Compile Commands Extractor for Bazel
 # https://github.com/hedronvision/bazel-compile-commands-extractor


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

- It can remove deps from host os.

## What is changing

- Define libaio in MODULE.bazel
- Adept the deps accordingly
- tweak CI

## Example


