### PR TITLE
ci: update to windows latest

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Generate Project
-        run: cmake -B Build/${{ matrix.mode }} -DCMAKE_BUILD_TYPE=${{ matrix.mode }} -DRFK_DEV=1 -G "Visual Studio 16 2019" -A x64
+        run: cmake -B Build/${{ matrix.mode }} -DCMAKE_BUILD_TYPE=${{ matrix.mode }} -DRFK_DEV=1 -G "Visual Studio 17 2022" -A x64
 
       - name: Build async_simple
         run: cmake --build Build/${{ matrix.mode }} --config ${{ matrix.mode }} --verbose


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Windows Server 2019 has been removed from GitHub Actions, causing the Windows CI to be stuck indefinitely.

## What is changing

Update to windows-latest.

## Example


