### PR TITLE
ci: fix macos cmake build

### DIFF
--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -32,8 +32,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: deps
-      run: brew install googletest
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/cmake/FindGTest.cmake
+++ b/cmake/FindGTest.cmake
@@ -10,7 +10,7 @@ else()
     FetchContent_Declare(
         googletest
         GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG release-1.11.0
+        GIT_TAG v1.17.0
         GIT_SHALLOW ON
     )
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

- 1.11 gtest is too old, causing cmake error.

## What is changing

- update to 1.17, remove redundant brew install

## Example


