### PR TITLE
ci: fix incorrect clang version for charconv warn

### DIFF
--- a/cmake/FindGTest.cmake
+++ b/cmake/FindGTest.cmake
@@ -13,8 +13,7 @@ else()
         GIT_TAG v1.17.0
         GIT_SHALLOW ON
     )
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND
-       CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "20")
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "21")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=character-conversion")
     endif()
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Based on https://github.com/llvm/llvm-project/commit/381a649fb991eadb0c594de2d8b6166fcc11345a, the warning `character-conversion` was introduced in clang21, not 20, causing the modules CI to fail.

## What is changing

## Example


