### PR TITLE
ci: drop gcc 11 & enable gcc 14

### DIFF
--- a/.github/workflows/cmake_gcc.yml
+++ b/.github/workflows/cmake_gcc.yml
@@ -14,7 +14,7 @@ jobs:
   build_with_gcc:
     strategy:
       matrix:
-        gcc_version: [10, 11, 12, 13]
+        gcc_version: [11, 12, 13, 14]
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

gcc 10 is the first version to have coroutine support. However, it is still buggy and causing issues in CI.

## What is changing

drop gcc 11 & enable gcc 14

## Example


