### PR TITLE
fix: surface SignalException in FutureAwaiter<void> await_resume

### DIFF
--- a/async_simple/coro/FutureAwaiter.h
+++ b/async_simple/coro/FutureAwaiter.h
@@ -106,8 +106,15 @@ struct FutureAwaiter {
         return true;
     }
     auto await_resume() {
-        if constexpr (!std::is_same_v<T, void>)
+        if constexpr (std::is_same_v<T, void>) {
+            // Inspect the result even for void: the cancellation path replaces
+            // future_ with a ready future carrying SignalException. Skipping
+            // value() here would silently swallow the cancellation and make
+            // the co_await return normally instead of throwing.
+            future_.value();
+        } else {
             return std::move(future_.value());
+        }
     }
 };
 }  // namespace coro::detail

--- a/async_simple/coro/test/FutureAwaiterTest.cpp
+++ b/async_simple/coro/test/FutureAwaiterTest.cpp
@@ -117,6 +117,51 @@ TEST_F(FutureAwaiterTest, testWithFutureCancel) {
         async_simple::coro::sleep(std::chrono::hours{60}).via(&ex1)));
 }
 
+TEST_F(FutureAwaiterTest, testWithFutureCancelVoid) {
+    async_simple::executors::SimpleExecutor ex1(2);
+    // cancel while awaiting: the Terminate handler resumes the coroutine and
+    // await_resume must surface the SignalException even for Future<void>.
+    auto lazy = [&]() -> Lazy<> {
+        Promise<void> pr;
+        auto fut = pr.getFuture();
+        async_simple::SignalType type = None;
+        try {
+            co_await std::move(fut);
+        } catch (const async_simple::SignalException& e) {
+            type = e.value();
+        } catch (...) {
+        }
+        EXPECT_EQ(type, async_simple::Terminate);
+    };
+    syncAwait(collectAll<async_simple::Terminate>(
+        lazy().via(&ex1),
+        async_simple::coro::sleep(std::chrono::microseconds{10}).via(&ex1)));
+    // pre-fired signal: the slot is already triggered, so the second
+    // co_await's tryEmplace fails and await_resume runs immediately.
+    auto lazy2 = [&]() -> Lazy<> {
+        Promise<void> pr1;
+        auto fut1 = pr1.getFuture();
+        try {
+            co_await std::move(fut1);
+        } catch (const async_simple::SignalException& e) {
+            EXPECT_EQ(e.value(), async_simple::Terminate);
+        }
+        Promise<void> pr2;
+        auto fut2 = pr2.getFuture();
+        async_simple::SignalType type = None;
+        try {
+            co_await std::move(fut2);
+        } catch (const async_simple::SignalException& e) {
+            type = e.value();
+        } catch (...) {
+        }
+        EXPECT_EQ(type, async_simple::Terminate);
+    };
+    syncAwait(collectAll<async_simple::Terminate>(
+        lazy2().via(&ex1),
+        async_simple::coro::sleep(std::chrono::microseconds{10}).via(&ex1)));
+}
+
 namespace detail {
 
 static_assert(HasGlobalCoAwaitOperator<Future<int>>);


### PR DESCRIPTION
Fixes #470

## Problem

`co_await Future<void>` does not throw `SignalException` when the awaiting task is cancelled — it returns normally instead. `FutureAwaiter<T>::await_resume()` is:

```cpp
auto await_resume() {
    if constexpr (!std::is_same_v<T, void>)
        return std::move(future_.value());
}
```

For `T = void` the function body is empty, so the cancellation-result future (a ready future carrying `SignalException`, installed by `await_suspend_cancellable()`) is never inspected and the exception is silently discarded — for both the mid-await cancellation path (Terminate handler resumes the coroutine) and the pre-fired-signal path (`tryEmplace` fails, `await_resume()` runs immediately).

## Fix

Inspect the result for `void` as well:

```cpp
auto await_resume() {
    if constexpr (std::is_same_v<T, void>) {
        future_.value();
    } else {
        return std::move(future_.value());
    }
}
```

`future_.value()` on a completed void future is a no-op (empty `Try<void>`), so the non-cancellation path is unaffected; the cancellation path now surfaces `SignalException` as expected.

## Verification

- Minimal reproduction (same shape as PR #428's test but with `Promise<void>` and the promise never fulfilled) now prints `threw: 1` (Terminate) instead of `returned normally (BUG)`.
- Existing `FutureAwaiter` tests still pass.
