### PR TITLE
fix two issues in PromiseAllocator.h

### DIFF
--- a/async_simple/coro/PromiseAllocator.h
+++ b/async_simple/coro/PromiseAllocator.h
@@ -20,6 +20,7 @@
 #ifndef ASYNC_SIMPLE_USE_MODULES
 #include <algorithm>
 #include <concepts>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <new>
@@ -30,10 +31,10 @@
 // The reason why `__cpp_sized_deallocation` is not enabled is that it will
 // cause ABI breaking
 #if defined(__clang__) && defined(__GLIBCXX__)
-#endif  // ASYNC_SIMPLE_USE_MODULES
-
 void operator delete[](void* p, std::size_t sz) noexcept;
 #endif
+
+#endif  // ASYNC_SIMPLE_USE_MODULES
 
 namespace async_simple::coro::detail {
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

#### 1.  add `#include<cstdint>` explicityly in PromiseAllocator.h for libstdc++ 15 and newer version

When compiling with GCC 15.1, a compilation error occurs in header `coro/PromiseAllocator.h`:
`/async_simple/async_simple/coro/PromiseAllocator.h:96:35: error: ‘uintptr_t’ does not name a type [-Wtemplate-body]
   96 |                 (reinterpret_cast<uintptr_t>(ptr) + size + alignof(Alloc) - 1) &
      |                                   ^~~~~~~~~`

> In older libstdc++ versions, headers such as `<memory>` and `<algorithm>` transitively include `<cstdint>`. Newer standard library releases have cleaned up these indirect header dependencies, so `<cstdint>` needs to be included explicitly.
I have verified this issue exists for libstdc++ 15 and above, see: https://godbolt.org/z/77hE6d675

#### 2.  correct #endif placement

While fixing the above issue, I found another minor problem in this header, introduced by commit c753166:
```
#ifndef ASYNC_SIMPLE_USE_MODULES
#include <algorithm>
// ...
#if defined(__clang__) && defined(__GLIBCXX__)
#endif  // ASYNC_SIMPLE_USE_MODULES

void operator delete[](void* p, std::size_t sz) noexcept;
#endif
```
The newly‑added `#endif  // ASYNC_SIMPLE_USE_MODULES` is misplaced. It incorrectly matches to line `#if defined(__clang__)` . This causes the `void operator delete[](void* p, std::size_t sz) noexcept;` declaration to always be visible outside the intended conditional guard. (No compile error occurs since it is merely a duplicate declaration.)

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

#### 1. Add explicit `#include <cstdint>` inside `async_simple/coro/PromiseAllocator.h`.
#### 2. Fix misplaced `#endif` position, corrected snippet:
```
#ifndef ASYNC_SIMPLE_USE_MODULES
#include <algorithm>
// ...
#if defined(__clang__) && defined(__GLIBCXX__)
void operator delete[](void* p, std::size_t sz) noexcept;
#endif
#endif  // ASYNC_SIMPLE_USE_MODULES
```


