### PR TITLE
Corrected the docs description of alignment requirement for Lazy<T>

### DIFF
--- a/docs/docs.en/Lazy.md
+++ b/docs/docs.en/Lazy.md
@@ -26,7 +26,7 @@ Lazy<int> task2(int x) {
 ## Alignment Requirement
 
 Due the limitation of ABI, Compiler Implementation and the usage
-of async_simple itself, we requrie the alignment of `T` in `Lazy<T>` can exceed `alignof(std::max_align_t)` (which is generally 16).
+of async_simple itself, we requrie the alignment of `T` in `Lazy<T>` can not exceed `alignof(std::max_align_t)` (which is generally 16).
 
 ## Start Lazy
 


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## Why
According to this static assert, the alignment requirement for type 'T' in 'Lazy<T>' should **not** exceed 'alignof(std::max_align_t)'.
``` cpp
#if defined(__clang__)
#pragma clang diagnostic push
#pragma clang diagnostic ignored "-Wgnu-alignof-expression"
    static_assert(alignof(T) <= alignof(std::max_align_t),
                  "async_simple doesn't allow Lazy with over aligned object");
#endif
```
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

Corrected the description of the alignment requirement for type 'T' in 'Lazy<T>' that it can **not** exceed 'alignof(std::max_align_t)'.

